### PR TITLE
Exit bootstrap script on error

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,7 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 
 indent() {
 	sed 's/^/    /'


### PR DESCRIPTION
Since commands are piped to "indent", the exit code of the piped command is ignored.
Adding "pipefail" will make said command fail also.

Fixes https://github.com/juliushaertl/nextcloud-docker-dev/issues/37