### PR TITLE
fixed sed for macos

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,11 @@ indent() {
 }
 
 indent_cli() {
-	sed -u 's/^/   > /'
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+  	sed -l 's/^/   > /'
+  else
+	  sed -u 's/^/   > /'
+	fi
 }
 
 function install_app() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,10 +9,10 @@ indent() {
 }
 
 indent_cli() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-  	sed -l 's/^/   > /'
-  else
-	  sed -u 's/^/   > /'
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		sed -l 's/^/   > /'
+	else
+		sed -u 's/^/   > /'
 	fi
 }
 


### PR DESCRIPTION
Uses "-l" instead of "-u" for sed under macOS.