### PR TITLE
fix(docker): stable24 works with sqlite only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,7 +351,7 @@ services:
   stable24:
     image: ghcr.io/juliushaertl/nextcloud-dev-php${PHP_VERSION:-74}:latest
     environment:
-      SQL: ${SQL:-mysql}
+      SQL: 'sqlite'
       NEXTCLOUD_AUTOINSTALL: "YES"
       NEXTCLOUD_AUTOINSTALL_APPS:
       WITH_REDIS: "YES"


### PR DESCRIPTION
I had problems to work stable24 with mysql. So, I think it's very nice to start stable24 with sqlite which works very well.

I ran `docker compose up stable24 proxy` command but I am stuck on running the mysql container.

```bash
$ docker compose up stable24 proxy
[+] Running 12/5
 ⠿ Network nextcloud_default               Created                                                   0.1s
 ⠿ Volume "nextcloud_data"                 Created                                                   0.0s
 ⠿ Volume "nextcloud_postgres"             Created                                                   0.0s
 ⠿ Volume "nextcloud_clam"                 Created                                                   0.0s
 ⠿ Volume "nextcloud_elasticsearch_data"   Created                                                   0.0s
[+] Running 16/15oud_mysql"                Created                                                   0.0s
 ⠿ Network nextcloud_default               Created                                                   0.1s
 ⠿ Volume "nextcloud_data"                 Created                                                   0.0s
 ⠿ Volume "nextcloud_postgres"             Created                                                   0.0s
 ⠿ Volume "nextcloud_clam"                 Created                                                   0.0s
 ⠿ Volume "nextcloud_elasticsearch_data"   Created                                                   0.0s
 ⠿ Volume "nextcloud_mysql"                Created                                                   0.0s
 ⠿ Volume "nextcloud_smbhomes"             Created                                                   0.0s
 ⠿ Volume "nextcloud_config"               Created                                                   0.0s
 ⠿ Volume "nextcloud_smb"                  Created                                                   0.0s
 ⠿ Volume "nextcloud_objectstorage_minio"  Created                                                   0.0s
 ⠿ Volume "nextcloud_document_log"         Created                                                   0.0s
 ⠿ Volume "nextcloud_document_data"        Created                                                   0.0s
 ⠿ Container nextcloud-proxy-1             Created                                                   0.1s
 ⠿ Container nextcloud-redis-1             Created                                                   0.1s
 ⠿ Container nextcloud-mail-1              Created                                                   0.1s
 ⠿ Container nextcloud-stable24-1          Created                                                   0.1s
Attaching to nextcloud-proxy-1, nextcloud-stable24-1
nextcloud-proxy-1     | Info: running nginx-proxy version 1.0.1-6-gc4ad18f
nextcloud-proxy-1     | Warning: The DHPARAM_GENERATION environment variable is deprecated, please consider using DHPARAM_SKIP set to true instead.
nextcloud-proxy-1     | Skipping Diffie-Hellman parameters setup.
nextcloud-proxy-1     | forego      | starting dockergen.1 on port 5000
nextcloud-proxy-1     | forego      | starting nginx.1 on port 5100
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: using the "epoll" event method
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: nginx/1.21.6
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: built by gcc 10.2.1 20210110 (Debian 10.2.1-6) 
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: OS: Linux 5.4.0-131-generic
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: getrlimit(RLIMIT_NOFILE): 1048576:1048576
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker processes
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 24
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 25
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 26
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 27
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 28
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 29
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 30
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 31
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Generated '/etc/nginx/conf.d/default.conf' from 3 containers
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Running 'nginx -s reload'
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Watching docker events
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 1 (SIGHUP) received from 37, reconfiguring
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: reconfiguring
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: using the "epoll" event method
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker processes
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 39
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 40
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 41
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 42
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 43
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 44
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 45
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 46
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 24#24: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 25#25: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 26#26: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 27#27: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 28#28: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 29#29: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 31#31: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 24#24: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 28#28: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 26#26: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 25#25: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 31#31: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 29#29: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 24#24: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 27#27: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 31#31: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 26#26: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 25#25: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 28#28: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 29#29: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 27#27: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 30#30: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 30#30: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 30#30: exit
nextcloud-stable24-1  | ⌛ Waiting for other containers
nextcloud-stable24-1  |  - MySQL
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 27
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 24 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 27 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 29 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 31
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 31 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 30
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 30 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 28
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 28 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 26
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 26 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 17 (SIGCHLD) received from 25
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: worker process 25 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Generated '/etc/nginx/conf.d/default.conf' from 4 containers
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Running 'nginx -s reload'
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: signal 1 (SIGHUP) received from 49, reconfiguring
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: reconfiguring
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:40 Received event start for container 0a0127537fea
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: using the "epoll" event method
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker processes
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 50
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 51
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 52
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 53
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 54
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 55
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 56
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 19#19: start worker process 57
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 40#40: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 39#39: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 42#42: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 43#43: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 45#45: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 46#46: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 41#41: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 45#45: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 46#46: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 40#40: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 39#39: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 42#42: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 41#41: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 45#45: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 46#46: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 43#43: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 40#40: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 39#39: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 42#42: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 41#41: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 43#43: exit
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 44#44: gracefully shutting down
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 44#44: exiting
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:40 [notice] 44#44: exit
nextcloud-proxy-1     | dockergen.1 | 2022/10/21 15:44:41 Contents of /etc/nginx/conf.d/default.conf did not change. Skipping notification 'nginx -s reload'
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 45
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 45 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 40 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 43 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 40
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 41
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 41 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 39
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 39 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 44
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 42 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 44 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 29 (SIGIO) received
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 17 (SIGCHLD) received from 46
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: worker process 46 exited with code 0
nextcloud-proxy-1     | nginx.1     | 2022/10/21 15:44:41 [notice] 19#19: signal 29 (SIGIO) received
^CGracefully stopping... (press Ctrl+C again to force)
```

So, what do you think Julius ?