### PR TITLE
WIP: Make the container work in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,42 @@ Features
 - 🚀 Blackfire
 - 📄 Collabora
 
+
+## Standalone containers
+
+::: tip
+This is a very simple way but doesn't cover all features. If you are looking for a fully featured setup you may skip to the next section
+:::
+
+There is a standalone version of the Nextcloud containers available that can be used to run Nextcloud without the other services. This is useful if you are just wanting to get started with app development against a speicifc server version, just just have a quick way to develop, test or debug.
+
+These containers support automatic fetching of the server source code and use SQLite as the database. The server source code is fetched from the official Nextcloud server repository and the version can be specified using the `NEXTCLOUD_VERSION` environment variable. The default version is `master`.
+
+Running the containers does not need this repository to be cloned.
+
+Example for running a Nextcloud server from the master branch of server:
+
+```bash
+docker run --rm -p 8080:80 ghcr.io/juliushaertl/nextcloud-dev-php80:latest
+```
+
+For app development you can mount your app directly into the container:
+
+```bash
+docker run --rm -p 8080:80 -v ~/path/to/appid:/var/www/html/apps-extra/appid ghcr.io/juliushaertl/nextcloud-dev-php80:latest
+```
+
+The `SERVER_BRANCH` environment variable can be used to run different versions of Nextcloud by specificing either a server branch or git tag.
+
+```bash
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/juliushaertl/nextcloud-dev-php80:latest
+```
+
+YOu can also mount your local server source code into the container to run a local version of Nextcloud:
+
+```bash
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/juliushaertl/nextcloud-dev-php80:latest
+```
 ## Simple master setup
 
 The easiest way to get the setup running the ```master``` branch is by running the ```bootstrap.sh``` script:

--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/

--- a/docker/configs/apcu.config.php
+++ b/docker/configs/apcu.config.php
@@ -1,0 +1,3 @@
+<?php $CONFIG=[
+  'memcache.local' => '\\OC\\Memcache\\APCu',
+];

--- a/docker/data/installing.html
+++ b/docker/data/installing.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta http-equiv="refresh" content="1" />
+        <meta charset="utf-8">
+        <style> 
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  margin: auto;
+  max-width: 700px;
+}
+
+.lds-ellipsis {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.lds-ellipsis div {
+  position: absolute;
+  top: 33px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #000;
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+.lds-ellipsis div:nth-child(1) {
+  left: 8px;
+  animation: lds-ellipsis1 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(2) {
+  left: 8px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(3) {
+  left: 32px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(4) {
+  left: 56px;
+  animation: lds-ellipsis3 0.6s infinite;
+}
+@keyframes lds-ellipsis1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes lds-ellipsis3 {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+@keyframes lds-ellipsis2 {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
+}
+        </style>
+    </head>
+    <body>
+        <h1>Installing container</h1>
+        <p>Please wait until the server is ready. This page will redirect you to the login once done.</p>
+        <h2>Log:</h2>
+        <div class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
+        <pre>

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -52,14 +52,22 @@ RUN pecl install APCu; \
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
-    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep \
+    git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
         && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN cd /tmp && curl -L https://phar.phpunit.de/phpunit.phar > phpunit.phar && \
-    chmod +x phpunit.phar && \
-    mv /tmp/phpunit.phar /usr/local/bin/phpunit
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
+    chmod +x /usr/local/bin/phpunit8 && \
+    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
+    chmod +x /usr/local/bin/phpunit9
 
+# Install NVM (Fermium = v14, Gallium = v16)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
+    && export NVM_DIR="/root/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install lts/gallium \
+    && nvm install lts/fermium \
+    && npm install -g npm@7
 RUN wget https://gist.githubusercontent.com/nickvergessen/e21ee0a09ee3b3f7fd1b04c83dd3e114/raw/83142be1e50c23e8de1bd7aae88a95e5d6ae1ce2/nextcloud_log.json && lnav -i nextcloud_log.json && rm nextcloud_log.json
 
 RUN { \
@@ -89,11 +97,23 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 RUN a2enmod rewrite
 
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+VOLUME /var/www/html
+VOLUME /var/www/html/apps-writable
+VOLUME /var/www/html/config
+VOLUME /var/www/html/data
+
+ENV SQL sqlite
+ENV NEXTCLOUD_AUTOINSTALL YES
+ENV WITH_REDIS NO
+
 ENV WEBROOT /var/www/html
 WORKDIR /var/www/html
 
 ENTRYPOINT  ["/usr/local/bin/bootstrap.sh"]
 CMD ["apache2-foreground"]
 
-ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php /root/
+ADD data/installing.html /root/installing.html
+ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/s3.php configs/config.php configs/redis.config.php configs/apcu.config.php /root/
 ADD bin/bootstrap.sh bin/occ /usr/local/bin/


### PR DESCRIPTION
First attempt to address https://github.com/juliushaertl/nextcloud-docker-dev/issues/81


```
make docker/Dockerfile.php80
docker run --rm -p 8080:80 ghcr.io/juliushaertl/nextcloud-dev-php80:latest
docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/juliushaertl/nextcloud-dev-php80:latest
docker run --rm -p 8080:80 -v ~/path/to/app:/var/www/html/apps-extra/app ghcr.io/juliushaertl/nextcloud-dev-php80:latest
docker run --rm -p 8080:80 -v ~/path/to/server:/var/www/html ghcr.io/juliushaertl/nextcloud-dev-php80:latest
```

- [x] Better handling of the installing screen (index.html)
- [x] Support for different server versions
- [x] Make sure to also clone other default apps (e.g. viewer)
- [x] Move the manually edited docker file changes to the template file
- [x] Test with mounted server code
- [ ] Check back with @christianlupus about possible additions from https://github.com/christianlupus/nextcloud-docker-debug
- [ ] Make running provisioning like ldap/oidc optional
- [x] Documentation

<details><summary>Changelog</summary>

- **🚚 The nextcloud-dev-php images are now also able to run in standalone mode.**
  This allows to spin up small development setups without the need for using the full docker-compose setup.
  If no volume mounts are provided the server source code will be fetched from master or a provided git tag through `SERVER_BRANCH`
    - Run a container for app development with the server master branch:
      ```bash
      docker run --rm -p 8080:80 ghcr.io/juliushaertl/nextcloud-dev-php80:latest
       ```
    - Run a container for app development with the server stable version 24.0.1 branch:
      ```bash
      docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/juliushaertl/nextcloud-dev-php80:latest
       ```
    - Develop an app with a local source code:
      ```bash
      docker run --rm -p 8080:80 -v ~/path/to/app:/var/www/html/apps-extra/app ghcr.io/juliushaertl/nextcloud-dev-php80:latest
       ```
    - For easier debugging you can also mount a local path for the server code (either an empty one or the path to your already checked out server codebase):
      ```bash
      docker run --rm -p 8080:80 -v ~/path/to/server:/var/www/html ghcr.io/juliushaertl/nextcloud-dev-php80:latest
       ```
- 📦 The following tools have been added to the php images to ease development for users that don't have those installed locally:
  - **composer** in the latest release available during image build
  - **PHPUnit** is available in two versions: `phpunit8` and `phpunit9`
  - **nvm** for managing Node.js versions with the following preinstalled ones:
      - **Node.js 14 and npm 7**
      - **Node.js 16 and npm 8**
</details>