### PR TITLE
Run /usr/sbin/update-ca-certificates regularly

### DIFF
--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -126,8 +126,8 @@ configure_ssl_proxy() {
 		echo "🗝 No SSL proxy, removing overwriteprotocol"
 		OCC config:system:delete overwriteprotocol
 		OCC config:system:set overwrite.cli.url --value "http://$VIRTUAL_HOST"
-
 	fi
+	update-ca-certificates
 }
 
 


### PR DESCRIPTION
Updating the OS trust store can be useful if you bind mount your SSL certs into the container and want to make REST calls from one instance to another. My docker-compose.yml looks something like this:

```
  nextcloud:
    volumes:
      - './data/ssl/nextcloud.home.arpa.crt:/usr/local/share/ca-certificates/nextcloud.home.arpa.crt'
      - './data/ssl/nextcloud2.home.arpa.crt:/usr/local/share/ca-certificates/nextcloud2.home.arpa.crt'
```