### PR TITLE
Allow logging of xdebug debug to setup dev environment easier

### DIFF
--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -350,6 +350,7 @@ pkill -USR1 apache2
 ) &
 
 touch /var/log/cron/nextcloud.log "$WEBROOT"/data/nextcloud.log /var/log/xdebug.log
+chown www-data /var/log/xdebug.log
 
 echo "📰 Watching log file"
 tail --follow "$WEBROOT"/data/nextcloud.log /var/log/cron/nextcloud.log /var/log/xdebug.log &

--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -349,10 +349,10 @@ pkill -USR1 apache2
 	pkill -USR1 apache2
 ) &
 
-touch /var/log/cron/nextcloud.log "$WEBROOT"/data/nextcloud.log
+touch /var/log/cron/nextcloud.log "$WEBROOT"/data/nextcloud.log /var/log/xdebug.log
 
 echo "📰 Watching log file"
-tail --follow "$WEBROOT"/data/nextcloud.log /var/log/cron/nextcloud.log &
+tail --follow "$WEBROOT"/data/nextcloud.log /var/log/cron/nextcloud.log /var/log/xdebug.log &
 
 echo "⌚ Starting cron"
 /usr/sbin/cron -f &

--- a/docker/configs/php/xdebug.ini
+++ b/docker/configs/php/xdebug.ini
@@ -5,7 +5,7 @@ xdebug.trace_output_name=trace.%R.%u
 xdebug.profiler_output_name=profile.%R.%u
 xdebug.output_dir=/shared
 
-xdebug.log = /shared/xdebug.log
+xdebug.log = /var/log/xdebug.log
 xdebug.log_level = 0
 
 # Try to discover the client host, otherwise fall back to the docker host

--- a/docker/configs/php/xdebug.ini
+++ b/docker/configs/php/xdebug.ini
@@ -6,7 +6,7 @@ xdebug.profiler_output_name=profile.%R.%u
 xdebug.output_dir=/shared
 
 xdebug.log = /var/log/xdebug.log
-xdebug.log_level = 0
+xdebug.log_level = 1
 
 # Try to discover the client host, otherwise fall back to the docker host
 xdebug.discover_client_host=true

--- a/docker/configs/php/xdebug.ini
+++ b/docker/configs/php/xdebug.ini
@@ -5,6 +5,9 @@ xdebug.trace_output_name=trace.%R.%u
 xdebug.profiler_output_name=profile.%R.%u
 xdebug.output_dir=/shared
 
+xdebug.log = /shared/xdebug.log
+xdebug.log_level = 0
+
 # Try to discover the client host, otherwise fall back to the docker host
 xdebug.discover_client_host=true
 xdebug.client_host=host.docker.internal

--- a/scripts/php-mod-config
+++ b/scripts/php-mod-config
@@ -44,7 +44,8 @@ then
     if [[ -n "$3" ]]
     then
         echo "Setting $2 to $3"
-        docker_exec "$1" sed -i 's/^'"$2"'\s*=\s*.*/'"$2"'='"$3"'/g' /usr/local/etc/php/conf.d/xdebug.ini
+        value="$(echo "$3" | sed 's@/@\\/@g')"
+        docker_exec "$1" sed -i 's/^'"$2"'\s*=\s*.*/'"$2"'='"$value"'/g' /usr/local/etc/php/conf.d/xdebug.ini
     else
         echo "No value provided"
         exit 1

--- a/scripts/php-mod-config
+++ b/scripts/php-mod-config
@@ -44,7 +44,7 @@ then
     if [[ -n "$3" ]]
     then
         echo "Setting $2 to $3"
-        value="$(echo "$3" | sed 's@/@\\/@g')"
+        value="${3//\//\\\/}"
         docker_exec "$1" sed -i 's/^'"$2"'\s*=\s*.*/'"$2"'='"$value"'/g' /usr/local/etc/php/conf.d/xdebug.ini
     else
         echo "No value provided"


### PR DESCRIPTION
This PR should simplify setting up the xdebug environment. You can use `scripts/php-mod-config` to alter the log location and level with that. However, a new build/push of the docker images is required by @juliushaertl.