### PR TITLE
Activate hmr_enabler by default in the bootstrap process

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,6 +72,7 @@ install_app viewer
 install_app recommendations
 install_app files_pdfviewer
 install_app profiler
+install_app hmr_enabler
 
 echo
 echo
@@ -83,7 +84,7 @@ DOMAIN_SUFFIX=.local
 REPO_PATH_SERVER=$PWD/workspace/server
 ADDITIONAL_APPS_PATH=$PWD/workspace/server/apps-extra
 STABLE_ROOT_PATH=$PWD/workspace
-NEXTCLOUD_AUTOINSTALL_APPS="viewer profiler"
+NEXTCLOUD_AUTOINSTALL_APPS="viewer profiler hmr_enabler"
 DOCKER_SUBNET=192.168.21.0/24
 PORTBASE=821
 EOT


### PR DESCRIPTION
Closes #129 

This change will only affect new installed instances as the `.env` file fill not be regenerated and new default apps will not be reinstalled (even if `workspace` is completely removed). I do not know if this should simply be communicated to the devs (my preference) or if there is anything to be coded.