### PR TITLE
install old ver of xdebug for PHP 7.1-7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ shellcheck:
 
 .ONESHELL:
 template-apply:
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.1/' > docker/Dockerfile.php71
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.2/' > docker/Dockerfile.php72
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.3/' > docker/Dockerfile.php73
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.4/' > docker/Dockerfile.php74
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.1/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php71
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.2/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php72
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.3/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php73
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.4/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php74
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.0/' > docker/Dockerfile.php80
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.1/' > docker/Dockerfile.php81
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.2/' > docker/php82/Dockerfile

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -37,7 +37,7 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 RUN pecl install APCu; \
     pecl install memcached; \
     pecl install redis; \
-    pecl install xdebug; \
+    pecl install xdebug-3.1.6; \
     pecl install imagick; \
     pecl install smbclient; \
     pecl install mcrypt; \

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -37,7 +37,7 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 RUN pecl install APCu; \
     pecl install memcached; \
     pecl install redis; \
-    pecl install xdebug-3.1.6; \
+    pecl install xdebug-2.9.8; \
     pecl install imagick; \
     pecl install smbclient; \
     pecl install mcrypt; \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -37,7 +37,7 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 RUN pecl install APCu; \
     pecl install memcached; \
     pecl install redis; \
-    pecl install xdebug; \
+    pecl install xdebug-3.1.6; \
     pecl install imagick; \
     pecl install smbclient; \
     pecl install mcrypt; \

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -37,7 +37,7 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 RUN pecl install APCu; \
     pecl install memcached; \
     pecl install redis; \
-    pecl install xdebug; \
+    pecl install xdebug-3.1.6; \
     pecl install imagick; \
     pecl install smbclient; \
     pecl install mcrypt; \

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -37,7 +37,7 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
 RUN pecl install APCu; \
     pecl install memcached; \
     pecl install redis; \
-    pecl install xdebug; \
+    pecl install xdebug-3.1.6; \
     pecl install imagick; \
     pecl install smbclient; \
     pecl install mcrypt; \


### PR DESCRIPTION
The old versions of PHP also need an old version of xdebug
fixes #142 