### PR TITLE
This makes the mailhog web interface available via the proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
           - stable23${DOMAIN_SUFFIX}
           - stable24${DOMAIN_SUFFIX}
           - stable25${DOMAIN_SUFFIX}
+          - mail${DOMAIN_SUFFIX}
           - collabora${DOMAIN_SUFFIX}
           - codedev${DOMAIN_SUFFIX}
           - onlyoffice${DOMAIN_SUFFIX}


### PR DESCRIPTION
The mailhog interface is not accessible through the proxy as the proxy does not detect the container. This PR should fix things