### PR TITLE
Fix script to creatte the hosts file

### DIFF
--- a/scripts/update-hosts
+++ b/scripts/update-hosts
@@ -9,7 +9,7 @@ function addhost() {
 	ETC_HOSTS=/etc/hosts
     HOSTNAME=$1
 	IP=$2
-    HOSTS_LINE="$IP\t${HOSTNAME}"
+    HOSTS_LINE="$( echo -e "$IP\t${HOSTNAME}" )"
     if grep -q "${HOSTNAME}" /etc/hosts
         then
             echo " ✅ ${HOSTNAME} already exists"


### PR DESCRIPTION
The script to generate the file in /etc/hosts outputs lines like this in my machine (Archlinux);
```
127.0.0.1\tnextcloud.local
```

I tried to fix it by evaluating the tab stops using echo once.