### PR TITLE
Add PROXY_PORT_HTTP and PROXY_PORT_HTTPS env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ cd data/ssl
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout  nextcloud.local.key -out nextcloud.local.crt
 ```
 
+You can also override the default port used for HTTP and HTTPS bound on the host for the proxy by setting these environment variables in the `.env` file (don't forget to recreate the containers):
+
+```
+PROXY_PORT_HTTP=8080
+PROXY_PORT_HTTPS=4443
+```
+
 ### dnsmasq to resolve wildcard domains
 
 Instead of adding the individual container domains to `/etc/hosts` a local dns server like dnsmasq can be used to resolve any domain ending with the configured DOMAIN_SUFFIX in `.env` to localhost.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
   proxy:
     image: ghcr.io/juliushaertl/nextcloud-dev-nginx:latest
     ports:
-      - "80:80"
-      - "443:443"
+      - "${PROXY_PORT_HTTP:-80}:80"
+      - "${PROXY_PORT_HTTPS:-443}:443"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./data/ssl/:/etc/nginx/certs


### PR DESCRIPTION
I need to use another port of http and https for the reverse proxy (the default ones are already used by my host).

I propose to introduce an environment variable for overriding the default ports. What do you think?