### PR TITLE
Increase timeout in nginx proxy

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,5 +1,2 @@
 FROM nginxproxy/nginx-proxy:latest
-RUN { \
-      echo 'server_tokens off;'; \
-      echo 'client_max_body_size 1024m;'; \
-    } > /etc/nginx/conf.d/my_proxy.conf
+ADD my_proxy.conf /etc/nginx/conf.d

--- a/docker/nginx/my_proxy.conf
+++ b/docker/nginx/my_proxy.conf
@@ -1,0 +1,6 @@
+server_tokens off;
+client_max_body_size 1024m;
+
+proxy_read_timeout 3600;
+proxy_send_timeout 3600;
+proxy_connect_timeout 3600;


### PR DESCRIPTION
This should increase the timeout of the nginx proxy as during step debugging, the proxy kills the request after 60 sec by default. This is rather short for a more involved debugging session.