### PR TITLE
Postgres port env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -486,9 +486,7 @@ services:
       POSTGRES_DB: nextcloud
       POSTGRES_PASSWORD: postgres
     ports:
-      - 5432:5432
-    expose:
-      - 5432
+      - "${PORTBASE:-800}2:5432"
     volumes:
       - postgres:/var/lib/postgresql
 


### PR DESCRIPTION
When I wanted to start the containers, I had a port conflict. This is due to the host listening already to the 5432 port.

I propose this patch, which makes PostgreSQL listen to the same port as would MySQL do if it were chosen.