### PR TITLE
In bootstrap, explicit the default database

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,6 +98,8 @@ NEXTCLOUD_AUTOINSTALL_APPS="${NEXTCLOUD_AUTOINSTALL_APPS[@]}"
 DOCKER_SUBNET=192.168.21.0/24
 PORTBASE=821
 XDEBUG_MODE=develop
+SQL=mysql # other values: "pgsql", "oci"
+DB_SERVICE=database-mysql # other values: "database-postgres"
 EOT
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -98,7 +98,8 @@ NEXTCLOUD_AUTOINSTALL_APPS="${NEXTCLOUD_AUTOINSTALL_APPS[@]}"
 DOCKER_SUBNET=192.168.21.0/24
 PORTBASE=821
 XDEBUG_MODE=develop
-SQL=mysql # other values: "pgsql", "oci"
+# SQL variant to use, possible values: sqlite, mysql, pgsql
+SQL=mysql
 DB_SERVICE=database-mysql # other values: "database-postgres"
 EOT
 fi


### PR DESCRIPTION
I propose to explicit the default database used in the `.env` file.

Therefore when one has to switch to the postgresql database, this change would guide what values set, and prevent the caveat to only set one of these two variables.