### PR TITLE
build: add WebP and AVIF support

### DIFF
--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -16,10 +16,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -16,10 +16,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif; \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
     docker-php-ext-install \
         exif \


### PR DESCRIPTION
WebP is available since PHP 5.4. AVIF is available since PHP 8.1.

See https://www.php.net/manual/en/function.imagewebp.php
and https://www.php.net/manual/en/function.imageavif.php


Closes #177
@juliushaertl 