### PR TITLE
fix: Avoid continuing image build if one extension build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ shellcheck:
 
 .ONESHELL:
 template-apply:
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.1/' | sed 's/pecl install xdebug/pecl install xdebug-2.9.8/' > docker/Dockerfile.php71
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.2/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php72
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.3/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php73
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.1/' | sed 's/pecl install xdebug/pecl install xdebug-2.9.8/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/' > docker/Dockerfile.php71
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.2/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/' > docker/Dockerfile.php72
+	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.3/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/'> docker/Dockerfile.php73
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.4/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php74
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.0/' > docker/Dockerfile.php80
 	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.1/' > docker/Dockerfile.php81

--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -25,8 +25,8 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         --with-freetype \
         --with-jpeg \
         --with-webp \
-        --with-avif; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -40,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -54,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
         --with-freetype \
         --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-webp && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-freetype-dir \
+        --with-jpeg-dir \
+        --with-webp-dir && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -17,11 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -35,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug-2.9.8; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug-2.9.8 && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -49,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug-2.9.8 && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-freetype-dir \
+        --with-jpeg-dir \
+        --with-webp-dir && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug-3.1.6 && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -17,11 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -35,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug-3.1.6; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug-3.1.6 && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -49,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-freetype-dir \
+        --with-jpeg-dir \
+        --with-webp-dir && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug-3.1.6 && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -17,11 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -35,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug-3.1.6; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug-3.1.6 && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -49,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
         --with-freetype \
         --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-webp && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug-3.1.6 && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -17,11 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -35,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug-3.1.6; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug-3.1.6 && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -49,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -17,11 +17,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -35,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -49,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
         --with-freetype \
         --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-webp && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -25,8 +25,8 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         --with-freetype \
         --with-jpeg \
         --with-webp \
-        --with-avif; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -40,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -54,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
         --with-freetype \
         --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-webp && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -44,7 +44,6 @@ RUN pecl install APCu && \
     pecl install xdebug && \
     pecl install imagick && \
     pecl install smbclient && \
-    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -17,15 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsmbclient-dev \
         libgmp-dev \
         libwebp-dev \
-        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
     docker-php-ext-configure gd \
         --with-freetype \
         --with-jpeg \
-        --with-webp \
-        --with-avif && \
+        --with-webp && \
     docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -16,11 +16,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libmagickcore-6.q16-3-extra \
         libsmbclient-dev \
         libgmp-dev \
+        libwebp-dev \
+        libavif-dev \
         && rm -rf /var/lib/apt/lists/*
 
 RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd --with-freetype --with-jpeg; \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-configure gd \
+        --with-freetype \
+        --with-jpeg \
+        --with-webp \
+        --with-avif && \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
     docker-php-ext-install \
         exif \
         gd \
@@ -34,13 +40,13 @@ RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
         sysvsem \
         gmp
 
-RUN pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
-    pecl install xdebug; \
-    pecl install imagick; \
-    pecl install smbclient; \
-    pecl install mcrypt; \
+RUN pecl install APCu && \
+    pecl install memcached && \
+    pecl install redis && \
+    pecl install xdebug && \
+    pecl install imagick && \
+    pecl install smbclient && \
+    pecl install mcrypt && \
     \
     docker-php-ext-enable \
         apcu \
@@ -48,7 +54,7 @@ RUN pecl install APCu; \
         redis \
         xdebug \
         imagick \
-        smbclient; \
+        smbclient && \
 	docker-php-source delete && \
 		rm -r /tmp/* /var/cache/*
 


### PR DESCRIPTION
Hopefully should fix #180 where my assumption is that image build failed to install the extensions but just continued without them