### PR TITLE
fix value for DB_SERVICE bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -100,7 +100,8 @@ PORTBASE=821
 XDEBUG_MODE=develop
 # SQL variant to use, possible values: sqlite, mysql, pgsql
 SQL=mysql
-DB_SERVICE=database-mysql # other values: "database-postgres"
+DB_SERVICE=database-mysql
+# other values: "database-postgres"
 EOT
 fi
 


### PR DESCRIPTION
this fixes the error in docker-compose.yml: "ERROR: Service 'nextcloud' depends on service 'database-mysql # other values: "database-postgres"' which is undefined." while running ´docker-compose up nextcloud proxy´