### PR TITLE
fix: Make autoinstall wait time configurable and 0 by default

### DIFF
--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -230,7 +230,7 @@ install() {
 		APP_ENABLED=$(OCC app:enable "$app")
 		output "$APP_ENABLED"
 		WAIT_TIME=0
-		until [ $WAIT_TIME -eq 120 ]  || [[ $APP_ENABLED =~ ${app}.*enabled$ ]]
+		until [[ $WAIT_TIME -eq ${NEXTCLOUD_AUTOINSTALL_APPS_WAIT_TIME:-0} ]] || [[ $APP_ENABLED =~ ${app}.*enabled$ ]]
 		do
 			# if app is not installed pause for 1 seconds and enable again
 			output "🔄 retrying"

--- a/example.env
+++ b/example.env
@@ -9,6 +9,8 @@ STABLE_ROOT_PATH=/home/jus/repos/nextcloud/
 
 # Install Nextcloud apps per default
 # NEXTCLOUD_AUTOINSTALL_APPS="viewer activity"
+# Retry enabling apps for a provided amount of time (can be useful when using the containers in CI)
+# NEXTCLOUD_AUTOINSTALL_APPS_WAIT_TIME=0
 
 # Blackfire configuration
 # BLACKFIRE_CLIENT_ID=


### PR DESCRIPTION
Otherwise this is quite annoying to wait for 120 seconds on local dev setups for apps that might not come up on initial startup
