### PR TITLE
Bump MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -499,7 +499,7 @@ services:
       - host.docker.internal:host-gateway
 
   database-mysql:
-    image: mariadb:10.5
+    image: mariadb:10.6
     environment:
       MYSQL_ROOT_PASSWORD: 'nextcloud'
       MYSQL_PASSWORD: 'nextcloud'


### PR DESCRIPTION
Bump MariaDB to latest recommended version 10.6, see https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html#server