### PR TITLE
Adjust mkcert documentation and add helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,7 @@ address=/.local/127.0.0.1
 
 * Install [mkcert](https://github.com/FiloSottile/mkcert)
 * Go to `data/ssl`
-* `mkcert nextcloud.local`
-
-* `mv nextcloud.local-key.pem nextcloud.local.key`
-* `mv nextcloud.local.pem nextcloud.local.crt`
+* `mkcert -cert-file nextcloud.local.crt -key-file nextcloud.local.key nextcloud.local`
 * `docker-compose restart proxy`
 
 ## ✉ Mail

--- a/scripts/update-certs
+++ b/scripts/update-certs
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+CERT_DIR="${SCRIPT_DIR}/../data/ssl/"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../.env"
+
+awk '$1 == "-"{ if (key == "aliases:") print $NF; next } {key=$1}' docker-compose.yml | \
+	sed "s/\${DOMAIN_SUFFIX}/${DOMAIN_SUFFIX}/" | \
+	while read -r line;
+	do
+        mkcert -cert-file "${CERT_DIR}${line}.crt" -key-file "${CERT_DIR}${line}.key" "${line}.crt"
+	done


### PR DESCRIPTION
`mkcert` allows to directly specify the names of the certificate and the key, no need to rename something anymore. Also used the `update-hosts` script as a template for `update-certs` to generate all in one go.