### PR TITLE
Add talk signaling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
           - smb
           - codedev
           - code
+          - talk-janus
     permissions:
       packages: write
       contents: read

--- a/README.md
+++ b/README.md
@@ -336,13 +336,13 @@ docker-compose exec ldap ldapsearch -H 'ldap://localhost' -D "cn=admin,dc=planet
 	- Enable the app and configure `onlyoffice.local` in the ONLYOFFICE settings inside of Nextcloud
 
 
-## Talk signaling
+## Talk HPB
 
 - Make sure to have the signaling hostname setup in your `/etc/hosts` file: `127.0.0.1 talk-signaling.local`
 - Automatically enable for one of your containers (e.g. the main `nextcloud` one):
-	- Run `./scripts/enable-talk-signaling.sh nextcloud`
+	- Run `./scripts/enable-talk-hpb.sh nextcloud`
 - Manual setup
-	- Start the talk signaling server in addition to your other containers `docker-compose up -d talk-signaling`
+	- Start the talk signaling server and janus in addition to your other containers `docker-compose up -d talk-signaling talk-janus`
 	- Go to the admin settings of talk and add the signaling server (`http://talk-signaling.local` with shared secret `1234`)
 
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,16 @@ docker-compose exec ldap ldapsearch -H 'ldap://localhost' -D "cn=admin,dc=planet
 	- Enable the app and configure `onlyoffice.local` in the ONLYOFFICE settings inside of Nextcloud
 
 
+## Talk signaling
+
+- Make sure to have the signaling hostname setup in your `/etc/hosts` file: `127.0.0.1 talk-signaling.local`
+- Automatically enable for one of your containers (e.g. the main `nextcloud` one):
+	- Run `./scripts/enable-talk-signaling.sh nextcloud`
+- Manual setup
+	- Start the talk signaling server in addition to your other containers `docker-compose up -d talk-signaling`
+	- Go to the admin settings of talk and add the signaling server (`http://talk-signaling.local` with shared secret `1234`)
+
+
 ## Antivirus
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -841,11 +841,18 @@ services:
       HTTP_LISTEN: "0.0.0.0:80"
       HASH_KEY: "11111111111111111111111111111111"
       BLOCK_KEY: "22222222222222222222222222222222"
-      USE_JANUS: 0
+      USE_JANUS: 1
+      JANUS_URL: "ws://talk-janus:8188"
       SKIP_VERIFY: 1
       BACKENDS_ALLOWALL: 1
       BACKENDS_ALLOWALL_SECRET: "1234"
       INTERNAL_SHARED_SECRET_KEY: "4567"
+
+  talk-janus:
+    build:
+      context: ./docker
+      dockerfile: talk-janus/Dockerfile
+    command: ["janus", "--full-trickle"]      
 
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -849,10 +849,7 @@ services:
       INTERNAL_SHARED_SECRET_KEY: "4567"
 
   talk-janus:
-    build:
-      context: ./docker
-      dockerfile: talk-janus/Dockerfile
-    command: ["janus", "--full-trickle"]      
+    image: ghcr.io/juliushaertl/nextcloud-dev-talk-janus:latest
 
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
           - elasticsearch-ui${DOMAIN_SUFFIX}
           - pgadmin${DOMAIN_SUFFIX}
           - phpmyadmin${DOMAIN_SUFFIX}
+          - talk-signaling${DOMAIN_SUFFIX}
 
   haproxy:
     image: haproxy
@@ -833,6 +834,18 @@ services:
     environment:
       - PORT=8088
 
+  talk-signaling:
+    image: strukturag/nextcloud-spreed-signaling:latest
+    environment:
+      VIRTUAL_HOST: "talk-signaling${DOMAIN_SUFFIX}"
+      HTTP_LISTEN: "0.0.0.0:80"
+      HASH_KEY: "11111111111111111111111111111111"
+      BLOCK_KEY: "22222222222222222222222222222222"
+      USE_JANUS: 0
+      SKIP_VERIFY: 1
+      BACKENDS_ALLOWALL: 1
+      BACKENDS_ALLOWALL_SECRET: "1234"
+      INTERNAL_SHARED_SECRET_KEY: "4567"
 
 volumes:
   data:

--- a/docker/talk-janus/Dockerfile
+++ b/docker/talk-janus/Dockerfile
@@ -46,4 +46,4 @@ RUN mkdir -p /usr/src/janus && \
 
 WORKDIR /usr/src/janus/janus-gateway-$JANUS_VERSION
 
-CMD [ "janus" ]
+CMD [ "janus", "--full-trickle" ]

--- a/docker/talk-janus/Dockerfile
+++ b/docker/talk-janus/Dockerfile
@@ -1,0 +1,49 @@
+# Taken from https://github.com/strukturag/nextcloud-spreed-signaling/blob/54c1af7f4f1b598a9f2c1ae37b76b37e9dda3ee8/docker/janus/Dockerfile
+
+# Modified from https://gitlab.com/powerpaul17/nc_talk_backend/-/blob/dcbb918d8716dad1eb72a889d1e6aa1e3a543641/docker/janus/Dockerfile
+FROM alpine:3.14
+
+RUN apk add --no-cache curl autoconf automake libtool pkgconf build-base \
+  glib-dev libconfig-dev libnice-dev jansson-dev openssl-dev zlib libsrtp-dev \
+  gengetopt libwebsockets-dev git curl-dev libogg-dev
+
+# usrsctp
+# 08 Oct 2021
+ARG USRSCTP_VERSION=7c31bd35c79ba67084ce029511193a19ceb97447
+
+RUN cd /tmp && \
+    git clone https://github.com/sctplab/usrsctp && \
+    cd usrsctp && \
+    git checkout $USRSCTP_VERSION && \
+    ./bootstrap && \
+    ./configure --prefix=/usr && \
+    make && make install
+
+# libsrtp
+ARG LIBSRTP_VERSION=2.4.2
+RUN cd /tmp && \
+    wget https://github.com/cisco/libsrtp/archive/v$LIBSRTP_VERSION.tar.gz && \
+    tar xfv v$LIBSRTP_VERSION.tar.gz && \
+    cd libsrtp-$LIBSRTP_VERSION && \
+    ./configure --prefix=/usr --enable-openssl && \
+    make shared_library && \
+    make install && \
+    rm -fr /libsrtp-$LIBSRTP_VERSION && \
+    rm -f /v$LIBSRTP_VERSION.tar.gz
+
+# JANUS
+
+ARG JANUS_VERSION=0.11.8
+RUN mkdir -p /usr/src/janus && \
+    cd /usr/src/janus && \
+    curl -L https://github.com/meetecho/janus-gateway/archive/v$JANUS_VERSION.tar.gz | tar -xz && \
+    cd /usr/src/janus/janus-gateway-$JANUS_VERSION && \
+    ./autogen.sh && \
+    ./configure --disable-rabbitmq --disable-mqtt --disable-boringssl && \
+    make && \
+    make install && \
+    make configs
+
+WORKDIR /usr/src/janus/janus-gateway-$JANUS_VERSION
+
+CMD [ "janus" ]

--- a/scripts/enable-talk-hpb.sh
+++ b/scripts/enable-talk-hpb.sh
@@ -16,7 +16,7 @@ function occ() {
 source .env
 
 echo "Setting up talk signaling with http://talk-signaling$DOMAIN_SUFFIX on $CONTAINER"
-docker-compose up -d talk-signaling
+docker-compose up -d talk-signaling talk-janus
 
 if ! occ talk:signaling:list --output="plain" | grep -q "http://talk-signaling$DOMAIN_SUFFIX"; then
   occ talk:signaling:add "http://talk-signaling$DOMAIN_SUFFIX" "1234"

--- a/scripts/enable-talk-signaling.sh
+++ b/scripts/enable-talk-signaling.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]
+  then
+    echo "Usage $0 CONTAINER"
+	exit 1
+fi
+
+CONTAINER=$1
+
+function occ() {
+    docker compose exec "$CONTAINER" sudo -E -u www-data "./occ" "$@"
+}
+
+# shellcheck disable=SC1091
+source .env
+
+echo "Setting up talk signaling with http://talk-signaling$DOMAIN_SUFFIX on $CONTAINER"
+docker-compose up -d talk-signaling
+
+if ! occ talk:signaling:list --output="plain" | grep -q "http://talk-signaling$DOMAIN_SUFFIX"; then
+  occ talk:signaling:add "http://talk-signaling$DOMAIN_SUFFIX" "1234"
+fi
+


### PR DESCRIPTION
This PR adds the high performance backend for talk (signaling server and janus) as optional containers to the dev environment.

Fixes #22 