### PR TITLE
feat: add oci extension for php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ shellcheck:
 
 .ONESHELL:
 template-apply:
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.1/' | sed 's/pecl install xdebug/pecl install xdebug-2.9.8/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/' > docker/Dockerfile.php71
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.2/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/' > docker/Dockerfile.php72
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.3/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' | sed -E 's/(--with-(freetype|jpeg|webp|avif))/\1-dir/'> docker/Dockerfile.php73
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:7.4/' | sed 's/pecl install xdebug/pecl install xdebug-3.1.6/' > docker/Dockerfile.php74
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.0/' > docker/Dockerfile.php80
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.1/' > docker/Dockerfile.php81
-	cat docker/Dockerfile.php.template | sed 's/php:8.1/php:8.2/' > docker/php82/Dockerfile
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:7.1/' > docker/Dockerfile.php71
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:7.2/' > docker/Dockerfile.php72
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:7.3/' > docker/Dockerfile.php73
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:7.4/' > docker/Dockerfile.php74
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:8.0/' > docker/Dockerfile.php80
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:8.1/' > docker/Dockerfile.php81
+	cat docker/Dockerfile.php.template | sed 's/php:8.2/php:8.2/' > docker/php82/Dockerfile

--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -1,70 +1,41 @@
-FROM php:8.1-apache
+FROM php:8.2-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -1,70 +1,41 @@
 FROM php:7.1-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype-dir \
-        --with-jpeg-dir \
-        --with-webp-dir && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug-2.9.8 && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -1,70 +1,41 @@
 FROM php:7.2-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype-dir \
-        --with-jpeg-dir \
-        --with-webp-dir && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug-3.1.6 && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -1,70 +1,41 @@
 FROM php:7.3-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype-dir \
-        --with-jpeg-dir \
-        --with-webp-dir && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug-3.1.6 && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -1,70 +1,41 @@
 FROM php:7.4-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug-3.1.6 && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -1,70 +1,41 @@
 FROM php:8.0-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -1,70 +1,41 @@
 FROM php:8.1-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -1,70 +1,41 @@
 FROM php:8.2-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        libcurl4-openssl-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libmcrypt-dev \
-        libmemcached-dev \
-        libpng-dev \
-        libpq-dev \
-        libxml2-dev \
-        libzip-dev \
-        libmagickwand-dev \
-        libmagickcore-6.q16-3-extra \
-        libsmbclient-dev \
-        libgmp-dev \
-        libwebp-dev \
-        && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
-    docker-php-ext-configure gd \
-        --with-freetype \
-        --with-jpeg \
-        --with-webp && \
-    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" && \
-    docker-php-ext-install \
-        exif \
-        gd \
-        intl \
-        ldap \
-        opcache \
-        pcntl \
-        pdo_mysql \
-        pdo_pgsql \
-        zip \
-        sysvsem \
-        gmp
+RUN chmod +x /usr/local/bin/install-php-extensions
 
-RUN pecl install APCu && \
-    pecl install memcached && \
-    pecl install redis && \
-    pecl install xdebug && \
-    pecl install imagick && \
-    pecl install smbclient && \
-    \
-    docker-php-ext-enable \
-        apcu \
-        memcached \
-        redis \
-        xdebug \
-        imagick \
-        smbclient && \
-	docker-php-source delete && \
-		rm -r /tmp/* /var/cache/*
+RUN install-php-extensions \
+    apcu \
+    bcmath \
+    blackfire \
+    exif \
+    gd \
+    gmp \
+    imagick \
+    intl \
+    ldap \
+    oci8 \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    redis \
+    smbclient \
+    sysvsem \
+    xdebug \
+    zip \
+    @composer
 
 # dev tools separate install so we quickly change without rebuilding all php extensions
 RUN apt update && apt-get install -y --no-install-recommends \
     git curl vim sudo cron smbclient iproute2 lnav wget iputils-ping gnupg2 jq ripgrep rsync \
-        && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # Install PHPUnit
-RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar && \
-    chmod +x /usr/local/bin/phpunit8 && \
-    wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar && \
-    chmod +x /usr/local/bin/phpunit9
+RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
+    && chmod +x /usr/local/bin/phpunit8 \
+    && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
+    && chmod +x /usr/local/bin/phpunit9
 
 # Install NVM (Fermium = v14, Gallium = v16)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
@@ -93,7 +64,7 @@ ADD configs/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
     && echo "deb http://packages.blackfire.io/debian any main" | sudo tee /etc/apt/sources.list.d/blackfire.list \
     && apt-get update  \
-    && (apt-get install -y --no-install-recommends blackfire-php blackfire \
+    && (apt-get install -y --no-install-recommends blackfire \
 		&& printf "\n\nblackfire.agent_socket=tcp://blackfire:8307\n" >> $PHP_INI_DIR/conf.d/zz-blackfire.ini && \
         mv $PHP_INI_DIR/conf.d/zz-blackfire.ini $PHP_INI_DIR/conf.d/zz-blackfire.ini.disabled) \
 		|| echo "Skipped blackfire as the installation failed" \
@@ -101,9 +72,11 @@ RUN wget -q -O - https://packages.blackfire.io/gpg.key | sudo apt-key add - \
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
-RUN a2enmod rewrite
+# mod_rewrite
+RUN a2enmod rewrite headers
 
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+# increase limit request body
+RUN echo "LimitRequestBody 0" > /etc/apache2/conf-available/limit-request-body.conf && a2enconf limit-request-body
 
 VOLUME /var/www/html
 VOLUME /var/www/html/apps-writable


### PR DESCRIPTION
and migrate the dockerfile to use https://github.com/mlocati/docker-php-extension-installer

What is `DEB_BUILD_MULTIARCH` about? 
If I understand the build right, then we use qemu to create the image with the target arch and the installer should use the right arch already?

Build on my fork: https://github.com/kesselb/nextcloud-docker-dev/pull/1