### PR TITLE
feat: add docker compose v2 support to bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -67,7 +67,12 @@ echo
 echo "⏩ Performing system checks"
 
 is_installed docker
-is_installed docker-compose
+
+(
+  (docker compose version >/dev/null 2>&1 && echo "✅ Docker Compose plugin is properly installed" | indent) ||
+	  (is_installed docker-compose)
+)
+
 is_installed git
 
 (


### PR DESCRIPTION
Docker Compose v2 has been out for a while, and is even provided by default in some installations. The `bootstrap.sh` file should support Docker Compose v2 out of the box.

This does not remove support for original `docker-compose` command. It just checks for the Docker Compose v2 plugin (`docker compose`) first, before falling back to the original check/behavior.

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
> …
> Docker’s documentation refers to and describes Compose V2 functionality.
> 
> — [Docker Documentation for Docker Compose](https://docs.docker.com/compose/)

Docker Compose v2 is a plugin for Docker that is used through the Docker command. (Notice the lack of hyphens.)

> ```sh
> docker compose up -d
> …
> docker compose down
> ```
> 
> — [Documentation for Automated Testing Environments](https://docs.docker.com/compose/features-uses/#automated-testing-environments) featuring Docker Compose v2 commands.

Unfortunately, I don't see a clear way to check if Docker Compose v2 is installed, other than just trying to do a command. So this PR takes that approach, and attempts to run the `docker compose version` command if it fails, then it's probably not installed.

## Demo

With Docker Compose plugin installed:

<details>
<summary><code>./bootstrap.sh</code></summary>

```sh

⏩ Performing system checks
    ✅ docker is properly installed
    ✅ Docker Compose plugin is properly installed
    ✅ git is properly installed
    ✅ Docker is properly executable
…
```

</details>

Without Docker Compose plugin or docker-compose installed:

<details>
<summary><code>./bootstrap.sh</code></summary>

```sh


⏩ Performing system checks
    ✅ docker is properly installed
    ❌ Install docker-compose before running this script
…
```

</details>