### PR TITLE
Fix syntax error in xdebug.ini in line 15

### DIFF
--- a/docker/configs/php/xdebug.ini
+++ b/docker/configs/php/xdebug.ini
@@ -1,4 +1,4 @@
- # off develop debug gcstats profile trace
+; off develop debug gcstats profile trace
 xdebug.mode = off
 xdebug.idekey=PHPSTORM
 xdebug.trace_output_name=trace.%R.%u
@@ -8,11 +8,11 @@ xdebug.output_dir=/shared
 xdebug.log = /var/log/xdebug.log
 xdebug.log_level = 1
 
-# Try to discover the client host, otherwise fall back to the docker host
+; Try to discover the client host, otherwise fall back to the docker host
 xdebug.discover_client_host=true
 xdebug.client_host=host.docker.internal
 
-# When you cannot specify a trigger, use "xdebug.start_with_request = yes" to autostart debugging for all requests
-# https://xdebug.org/docs/all_settings#start_with_request
+; When you cannot specify a trigger, use "xdebug.start_with_request = yes" to autostart debugging for all requests
+; https://xdebug.org/docs/all_settings#start_with_request
 xdebug.start_with_request = trigger
 xdebug.trace_format=0


### PR DESCRIPTION
I followed the simple master setup to set up the development environment. After trying to enable the debug mode as explained in the `README.md` I encountered an error that there is a syntax error in line 15 of the `xdebug.ini` config.

I checked and apparently PHP is interpreting the `"` and the `=` even though it is part of a comment. The solution was to use the native PHP comment function via `;` intead of `#`

I guess the use of `#` is [deprecated?](https://www.php.net/manual/en/function.parse-ini-file.php)

