### PR TITLE
Disable image builing on forked repositories

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
   push_to_registry:
     name: Build image
     runs-on: ubuntu-latest
+    if: github.repository == "juliushaertl/nextcloud-docker-dev"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
   push_to_registry:
     name: Build image
     runs-on: ubuntu-latest
-    if: github.repository == "juliushaertl/nextcloud-docker-dev"
+    if: github.repository == 'juliushaertl/nextcloud-docker-dev'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The daily cronjb triggers nighly failures on forks. This should prevent this by disabling the build on forks (hopefully).