### PR TITLE
Remove bad comment signs from xdebug config INI file

### DIFF
--- a/docker/configs/php/xdebug.ini
+++ b/docker/configs/php/xdebug.ini
@@ -1,4 +1,4 @@
- # off develop debug gcstats profile trace
+; off develop debug gcstats profile trace
 xdebug.mode = off
 xdebug.idekey=PHPSTORM
 xdebug.trace_output_name=trace.%R.%u
@@ -8,11 +8,11 @@ xdebug.output_dir=/shared
 xdebug.log = /var/log/xdebug.log
 xdebug.log_level = 1
 
-# Try to discover the client host, otherwise fall back to the docker host
+; Try to discover the client host, otherwise fall back to the docker host
 xdebug.discover_client_host=true
 xdebug.client_host=host.docker.internal
 
-# When you cannot specify a trigger, use "xdebug.start_with_request = yes" to autostart debugging for all requests
-# https://xdebug.org/docs/all_settings#start_with_request
+; When you cannot specify a trigger, use "xdebug.start_with_request = yes" to autostart debugging for all requests
+; https://xdebug.org/docs/all_settings#start_with_request
 xdebug.start_with_request = trigger
 xdebug.trace_format=0


### PR DESCRIPTION
The `#` is no valid comment sign in INI files. Thus there is a warning in the PHP logs about wrong chars in the comments.