### PR TITLE
Remove .crt from the wildcard when create certificate pairs

### DIFF
--- a/scripts/update-certs
+++ b/scripts/update-certs
@@ -10,5 +10,5 @@ awk '$1 == "-"{ if (key == "aliases:") print $NF; next } {key=$1}' docker-compos
 	sed "s/\${DOMAIN_SUFFIX}/${DOMAIN_SUFFIX}/" | \
 	while read -r line;
 	do
-        mkcert -cert-file "${CERT_DIR}${line}.crt" -key-file "${CERT_DIR}${line}.key" "${line}.crt"
+        mkcert -cert-file "${CERT_DIR}${line}.crt" -key-file "${CERT_DIR}${line}.key" "${line}"
 	done


### PR DESCRIPTION
Regression from #197 

`.crt` was added to the name certificates, making it invalid and showing NET::ERR_CERT_COMMON_NAME_INVALID error in browser

Left - Before | Right - After
![image](https://github.com/juliushaertl/nextcloud-docker-dev/assets/93392545/ab843a24-df1b-45b6-8041-937297073bc0)