### PR TITLE
Add talk recording server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
           - pgadmin${DOMAIN_SUFFIX}
           - phpmyadmin${DOMAIN_SUFFIX}
           - talk-signaling${DOMAIN_SUFFIX}
+          - talk-recording${DOMAIN_SUFFIX}
 
   haproxy:
     image: haproxy
@@ -951,6 +952,21 @@ services:
   talk-janus:
     image: ghcr.io/juliushaertl/nextcloud-dev-talk-janus:latest
 
+  talk-recording:
+    image: nextcloud/aio-talk-recording:latest
+    environment:
+      NC_DOMAIN: "nextcloud${DOMAIN_SUFFIX}"
+      ALLOW_ALL: true
+      HPB_PROTOCOL: "${PROTOCOL:-http}"
+      HPB_DOMAIN: "talk-signaling${DOMAIN_SUFFIX}"
+      HPB_PATH : ""
+      SKIP_VERIFY: true
+      RECORDING_SECRET: "6789"
+      INTERNAL_SECRET: "4567"
+      VIRTUAL_HOST: "talk-recording${DOMAIN_SUFFIX}"
+      VIRTUAL_PORT: 1234
+    shm_size: 2147483648
+    
 volumes:
   data:
   config:

--- a/docker/configs/php/nextcloud.ini
+++ b/docker/configs/php/nextcloud.ini
@@ -10,3 +10,6 @@ opcache.revalidate_freq=1
 
 apc.enable_cli=1
 memory_limit=512M
+
+upload_max_filesize=512M
+post_max_size=512M

--- a/docs/services/talk.md
+++ b/docs/services/talk.md
@@ -1,4 +1,6 @@
-# Talk HPB
+# Talk
+
+## HPB
 
 - Make sure to have the signaling hostname setup in your `/etc/hosts` file: `127.0.0.1 talk-signaling.local`
 - Automatically enable for one of your containers (e.g. the main `nextcloud` one):
@@ -6,3 +8,10 @@
 - Manual setup
   - Start the talk signaling server and janus in addition to your other containers `docker compose up -d talk-signaling talk-janus`
   - Go to the admin settings of talk and add the signaling server (`http://talk-signaling.local` with shared secret `1234`)
+
+## Recording
+
+- Make sure to have the recording hostname setup in your `/etc/hosts` file: `127.0.0.1 talk-recording.local`
+- Make sure the Talk HPB is running and configured
+- Start the talk recording server in addition to your other containers `docker-compose up -d talk-recording`
+- Go to the admin settings of talk and add the signaling server (`http://talk-recording.local` with shared secret `6789`)


### PR DESCRIPTION
~~Currently blocked by https://github.com/nextcloud/all-in-one/issues/3570~~

~~Uses `http` by default, should be better with https://github.com/juliushaertl/nextcloud-docker-dev/pull/214~~