### PR TITLE
Fix syntax problem in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -668,7 +668,7 @@ services:
     image: onlyoffice/documentserver:latest
     environment:
       VIRTUAL_HOST: onlyoffice${DOMAIN_SUFFIX}
-      USE_UNAUTHORIZED_STORAGE: true
+      USE_UNAUTHORIZED_STORAGE: "true"
     expose:
       - '80'
     volumes:


### PR DESCRIPTION
services.onlyoffice.environment.USE_UNAUTHORIZED_STORAGE contains true, which is an invalid type, it should be a string, number, or a null