### PR TITLE
Force enable richdocuments app

### DIFF
--- a/scripts/enable-collabora
+++ b/scripts/enable-collabora
@@ -23,7 +23,7 @@ function occ() {
 
 echo "Setting up Collabora with collabora$DOMAIN_SUFFIX on $CONTAINER"
 docker_compose up -d collabora
-occ app:enable richdocuments
+occ app:enable richdocuments --force
 occ config:app:set richdocuments wopi_url --value="${PROTOCOL:-http}://collabora${DOMAIN_SUFFIX}"
 occ config:app:set richdocuments public_wopi_url --value="${PROTOCOL:-http}://collabora${DOMAIN_SUFFIX}"
 occ config:app:set richdocuments disable_certificate_verification --value="yes"


### PR DESCRIPTION
Same as done for onlyoffice: 
https://github.com/juliushaertl/nextcloud-docker-dev/blob/ca8b6e5b3b1f786f9d686420e0ef757ae4a59b85/scripts/enable-onlyoffice#L23