### PR TITLE
Update stable-versions.md

### DIFF
--- a/docs/basics/stable-versions.md
+++ b/docs/basics/stable-versions.md
@@ -31,6 +31,7 @@ git worktree add ../../../stable28/apps/viewer stable28
 ```bash
 docker compose up -d stable28
 ```
+You can now access the stable Nextcloud instance at [http://stable28.local](http://stable28.local).
 
 ## Apps without stable branches
 


### PR DESCRIPTION
Hi!
I added information on which domain a stable version uses. Without the information, I expected the stable versions to be accessible at nextcloud.local like the default container.

Thank you for the nice project!