### PR TITLE
Fix non-string parameters for talk-recording

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -965,11 +965,11 @@ services:
     image: nextcloud/aio-talk-recording:latest
     environment:
       NC_DOMAIN: "nextcloud${DOMAIN_SUFFIX}"
-      ALLOW_ALL: true
+      ALLOW_ALL: "true"
       HPB_PROTOCOL: "${PROTOCOL:-http}"
       HPB_DOMAIN: "talk-signaling${DOMAIN_SUFFIX}"
       HPB_PATH : ""
-      SKIP_VERIFY: true
+      SKIP_VERIFY: "true"
       RECORDING_SECRET: "6789"
       INTERNAL_SECRET: "4567"
       VIRTUAL_HOST: "talk-recording${DOMAIN_SUFFIX}"


### PR DESCRIPTION
Fix review comment from https://github.com/juliushaertl/nextcloud-docker-dev/pull/239#discussion_r1470785886

Interesting that it worked fine here 🤔 

CC @mahibi