### PR TITLE
Fix bootstrap.sh error message when docker-compose is not installed

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -178,6 +178,7 @@ echo "⏩ Performing system checks"
 is_installed docker
 is_installed git
 
+DCC=
 docker-compose version >/dev/null 2>/dev/null && DCC='docker-compose'
 docker compose version >/dev/null 2>/dev/null && DCC='docker compose'
 


### PR DESCRIPTION
Otherwise, bash would output `./bootstrap.sh: line 184: DCC: unbound variable`, which isn't as helpful as `❌ Install docker-compose before running this script`.