### PR TITLE
Add a symbolic link for phpunit

### DIFF
--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -36,7 +36,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \

--- a/docker/php83/Dockerfile
+++ b/docker/php83/Dockerfile
@@ -37,7 +37,8 @@ RUN apt update && apt-get install -y --no-install-recommends \
 RUN wget -O /usr/local/bin/phpunit8 https://phar.phpunit.de/phpunit-8.phar \
     && chmod +x /usr/local/bin/phpunit8 \
     && wget -O /usr/local/bin/phpunit9 https://phar.phpunit.de/phpunit-9.phar \
-    && chmod +x /usr/local/bin/phpunit9
+    && chmod +x /usr/local/bin/phpunit9 \
+    && ln -s /usr/local/bin/phpunit9 /usr/local/bin/phpunit
 
 # Install NVM
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \


### PR DESCRIPTION
Today it took me way too long to figure out that PHPUnit is already available inside the containers. Therefore I suggest that we link `phpunit` to the latest installed phpunit (version 9 in this case).