### PR TITLE
feat: add appapi-dsp/appapi-dsp-https service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules/
 /tests/playwright-report/
 /tests/blob-report/
 /tests/playwright/.cache/
+/.idea/
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1040,6 +1040,40 @@ services:
       VIRTUAL_PORT: 1234
     shm_size: 2147483648
 
+  appapi-dsp:
+    image: ghcr.io/cloud-py-api/nextcloud-appapi-dsp:release
+    container_name: nextcloud-appapi-dsp-http
+    network_mode: ${NETWORK_MODE:-master_default}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - NC_HAPROXY_PASSWORD=${NC_HAPROXY_PASSWORD:-some_secure_password}
+      - BIND_ADDRESS=${BIND_ADDRESS:-}
+      - HAPROXY_PORT=${HAPROXY_PORT:-2375}
+      - TIMEOUT_CONNECT=${TIMEOUT_CONNECT:-10s}
+      - TIMEOUT_CLIENT=${TIMEOUT_CLIENT:-30s}
+      - TIMEOUT_SERVER=${TIMEOUT_SERVER:-30s}
+      - EX_APPS_NET=${EX_APPS_NET:-ipv4@localhost}
+      - EX_APPS_COUNT=${EX_APPS_COUNT:-50}
+
+  appapi-dsp-https:
+    image: ghcr.io/cloud-py-api/nextcloud-appapi-dsp:release
+    container_name: nextcloud-appapi-dsp-https
+    network_mode: ${NETWORK_MODE:-host}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${CERT_PATH:-./data/ssl/app_api/app_api.pem}:/certs/cert.pem
+    environment:
+      - NC_HAPROXY_PASSWORD=${NC_HAPROXY_PASSWORD:-some_secure_password}
+      - BIND_ADDRESS=${BIND_ADDRESS:-172.17.0.1}
+      - HAPROXY_PORT=${HAPROXY_PORT:-2375}
+      - TIMEOUT_CONNECT=${TIMEOUT_CONNECT:-10s}
+      - TIMEOUT_CLIENT=${TIMEOUT_CLIENT:-30s}
+      - TIMEOUT_SERVER=${TIMEOUT_SERVER:-30s}
+      - EX_APPS_NET=${EX_APPS_NET:-ipv4@localhost}
+      - EX_APPS_COUNT=${EX_APPS_COUNT:-50}
+
+
 volumes:
   data:
   config:

--- a/docs/services/app_api.md
+++ b/docs/services/app_api.md
@@ -1,0 +1,76 @@
+# AppAPI
+
+For [AppAPI](https://github.com/cloud-py-api/app_api) the [Docker Socket Proxy](https://github.com/cloud-py-api/docker-socket-proxy) (DSP) is required to work.
+
+## HTTP AppAPI DSP
+
+### 1. Start the HTTP DSP container
+
+```bash
+docker compose up -d appapi-dsp
+```
+
+### 2. Configure Deploy daemon
+
+After the DSP container is running, configure the Deploy daemon in AppAPI admin settings with the following parameters:
+
+- **Host**: `http://nextcloud-appapi-dsp-http:2375`
+- **Nextcloud URL**: `http://nextcloud.local` (locally always use http)
+- **Enable https**: `false`
+- **Network**: `master_default` (the network of nextcloud-docker-dev docker-compose, by default it is `master_default`)
+- **HaProxy password**: `some_secure_password`
+
+
+## HTTPS AppAPI DSP
+
+For HTTPS DSP setup, please refer to the [HTTPS (remote)](https://github.com/cloud-py-api/docker-socket-proxy?tab=readme-ov-file#httpsremote) section.
+
+### 1. Generate self-signed certificates
+
+Following the instruction from the DSP repository, generate and place the self-signed certificate in the `nextcloud-docker-dev/data/ssl/app_api/app_api.pem` directory.
+
+> **Note**: Additionally, you can copy the `app_api.pem` file to the `nextcloud-docker-dev/data/shared` directory 
+> to be able to access it for import in each nextcloud dev container (e.g. `occ security:certificates:import /shared/app_api.pem`).
+
+### 2. Start the HTTPS DSP container
+
+```bash
+docker compose up -d appapi-dsp-https
+```
+
+### 3. Configure Deploy daemon
+
+After the DSP container is running and the certificate is imported in Nextcloud, configure the Deploy daemon in AppAPI admin settings with the following parameters:
+
+- **Host**: `https://<nextcloud-appapi-dsp-https or BIND_ADDRESS IP>:2375` (use host depending on your setup)
+- **Nextcloud URL**: `http://nextcloud.local` (locally always use http)
+- **Enable https**: `true`
+- **Network**: `host` (with https enabled, the network is forced to `host`)
+- **HaProxy password**: `some_secure_password`
+
+
+## Environment variables
+
+The list of available environment variables for the AppAPI DSP is listed in its repository,
+and in the `example.env` file.
+
+## Troubleshooting
+
+### Image of AppAPI DSP is not accessible
+
+In case the AppAPI DSP image is not accessible, you can build it locally by cloning the [Docker Socket Proxy](https://github.com/cloud-py-api/docker-socket-proxy) repository and running the following commands:
+
+```bash
+git clone https://github.com/cloud-py-api/docker-socket-proxy.git
+```
+
+```bash
+cd docker-socket-proxy 
+```
+
+```bash
+ docker build -f ./Dockerfile -t nextcloud-appapi-dsp:latest ./
+```
+
+After that change the image name in the `docker-compose.yml` file
+for `appapi-dsp` or `appapi-dsp-https` service to `nextcloud-appapi-dsp:latest` and try again.

--- a/docs/services/app_api.md
+++ b/docs/services/app_api.md
@@ -20,6 +20,11 @@ After the DSP container is running, configure the Deploy daemon in AppAPI admin 
 - **Network**: `master_default` (the network of nextcloud-docker-dev docker-compose, by default it is `master_default`)
 - **HaProxy password**: `some_secure_password`
 
+or via OCC CLI:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:daemon:register dsp_http "DSP HTTP" docker-install http "http://nextcloud.local" --net=master_default --set-default
+```
 
 ## HTTPS AppAPI DSP
 
@@ -47,6 +52,12 @@ After the DSP container is running and the certificate is imported in Nextcloud,
 - **Enable https**: `true`
 - **Network**: `host` (with https enabled, the network is forced to `host`)
 - **HaProxy password**: `some_secure_password`
+
+or via OCC CLI:
+
+```bash
+./scripts/occ.sh nextcloud -- app_api:daemon:register dsp_https "DSP HTTPS" docker-install https "http://nextcloud.local" --net=host --set-default
+```
 
 
 ## Environment variables

--- a/example.env
+++ b/example.env
@@ -49,3 +49,17 @@ SQL=mysql
 # The mode of the xdebuger extention. This can be a comma separated list of
 # the entries none, develop, debug, trace, and profile.
 PHP_XDEBUG_MODE=develop
+
+# Nextcloud AppAPI Docker Socket Proxy
+# ------------------------------------
+# NC_HAPROXY_PASSWORD=some_secure_password
+# BIND_ADDRESS=172.17.0.1
+# CERT_PATH=./data/ssl/app_api/app_api.pem
+# NETWORK_MODE=host
+# HAPROXY_PORT=2375
+# TIMEOUT_CONNECT=10s
+# TIMEOUT_CLIENT=30s
+# TIMEOUT_SERVER=30s
+# EX_APPS_NET=ipv4@localhost
+# EX_APPS_COUNT=50
+# ------------------------------------


### PR DESCRIPTION
This PR adds two services (http and https) for [AppAPI Docker Socket Proxy](https://github.com/cloud-py-api/docker-socket-proxy) + short docs page on that for dev setup.