### PR TITLE
Fix doubled depth filter

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -141,7 +141,7 @@ function install_server() {
 	(
 		(
 			echo "🌏 Fetching server (this might take a while to finish)" &&
-				git clone ${CLONE_PARAMS[@]+"${CLONE_PARAMS[@]}"} https://github.com/nextcloud/server.git --depth 1 workspace/server --progress 2>&1 &&
+				git clone ${CLONE_PARAMS[@]+"${CLONE_PARAMS[@]}"} https://github.com/nextcloud/server.git workspace/server --progress 2>&1 &&
 				cd workspace/server && git submodule update --init --progress 2>&1
 		) || echo "❌ Failed to clone Nextcloud server code"
 	) | indent


### PR DESCRIPTION
I had a bug introduced in #228 that I just saw now. I had forgotten to remove the `--depth 1` from the git command, although it will be provided by means of `CLONE_PARAMS`. This is just a quick fix to get it running.