### PR TITLE
chore: update nextcloud-appapi-dsp image link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1041,7 +1041,7 @@ services:
     shm_size: 2147483648
 
   appapi-dsp:
-    image: ghcr.io/cloud-py-api/nextcloud-appapi-dsp:release
+    image: ghcr.io/nextcloud/nextcloud-appapi-dsp:release
     container_name: nextcloud-appapi-dsp-http
     network_mode: ${NETWORK_MODE:-master_default}
     volumes:
@@ -1057,7 +1057,7 @@ services:
       - EX_APPS_COUNT=${EX_APPS_COUNT:-50}
 
   appapi-dsp-https:
-    image: ghcr.io/cloud-py-api/nextcloud-appapi-dsp:release
+    image: ghcr.io/nextcloud/nextcloud-appapi-dsp:release
     container_name: nextcloud-appapi-dsp-https
     network_mode: ${NETWORK_MODE:-host}
     volumes:

--- a/docs/services/app_api.md
+++ b/docs/services/app_api.md
@@ -1,6 +1,6 @@
 # AppAPI
 
-For [AppAPI](https://github.com/cloud-py-api/app_api) the [Docker Socket Proxy](https://github.com/cloud-py-api/docker-socket-proxy) (DSP) is required to work.
+For [AppAPI](https://github.com/nextcloud/app_api) the [Docker Socket Proxy](https://github.com/nextcloud/docker-socket-proxy) (DSP) is required to work.
 
 ## HTTP AppAPI DSP
 
@@ -28,7 +28,7 @@ or via OCC CLI:
 
 ## HTTPS AppAPI DSP
 
-For HTTPS DSP setup, please refer to the [HTTPS (remote)](https://github.com/cloud-py-api/docker-socket-proxy?tab=readme-ov-file#httpsremote) section.
+For HTTPS DSP setup, please refer to the [HTTPS (remote)](https://github.com/nextcloud/docker-socket-proxy?tab=readme-ov-file#httpsremote) section.
 
 ### 1. Generate self-signed certificates
 
@@ -69,10 +69,10 @@ and in the `example.env` file.
 
 ### Image of AppAPI DSP is not accessible
 
-In case the AppAPI DSP image is not accessible, you can build it locally by cloning the [Docker Socket Proxy](https://github.com/cloud-py-api/docker-socket-proxy) repository and running the following commands:
+In case the AppAPI DSP image is not accessible, you can build it locally by cloning the [Docker Socket Proxy](https://github.com/nextcloud/docker-socket-proxy) repository and running the following commands:
 
 ```bash
-git clone https://github.com/cloud-py-api/docker-socket-proxy.git
+git clone https://github.com/nextcloud/docker-socket-proxy.git
 ```
 
 ```bash


### PR DESCRIPTION
Update docker-socket-proxy image link, https://github.com/nextcloud/docker-socket-proxy and https://github.com/nextcloud/app_api links. They have been transferred to Nextcloud org recently.