### PR TITLE
feat(push): always use latest released version

### DIFF
--- a/docker/push/Dockerfile
+++ b/docker/push/Dockerfile
@@ -1,6 +1,10 @@
 FROM alpine
 
-RUN wget https://github.com/nextcloud/notify_push/releases/download/v1.1.0/notify_push-`uname -m`-unknown-linux-musl -O /notify_push && chmod +x /notify_push && /notify_push --version
+RUN apk add curl jq \
+  && latest_tag=$(curl -Ls https://api.github.com/repos/nextcloud/notify_push/releases/latest | jq -r '.tag_name') \
+  && wget https://github.com/nextcloud/notify_push/releases/download/${latest_tag}/notify_push-`uname -m`-unknown-linux-musl -O /notify_push \
+  && chmod +x /notify_push \
+  && /notify_push --version
 
 EXPOSE 7867
 


### PR DESCRIPTION
With this change the container will always be rebuilt using the latest available release of `notify_push`.

as suggested in https://github.com/juliusknorr/nextcloud-docker-dev/pull/406#discussion_r2268584829