### PR TITLE
Remove duplicate minio alias from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,6 @@ services:
           - phpmyadmin${DOMAIN_SUFFIX}
           - talk-signaling${DOMAIN_SUFFIX}
           - talk-recording${DOMAIN_SUFFIX}
-          - minio${DOMAIN_SUFFIX}
     extra_hosts:
       - host.docker.internal:host-gateway
 


### PR DESCRIPTION
minio${DOMAIN_SUFFIX} is listed twice in network default aliases which give error when running 'docker-compose up -d nextcloud'