### PR TITLE
Fix bind-mounted app directories being overridden by anonymous volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -619,9 +619,9 @@ services:
       - '${STABLE_ROOT_PATH}/stable31:/var/www/html'
       - '${STABLE_ROOT_PATH}/stable31/apps-extra:/var/www/html/apps-extra'
       - '${ADDITIONAL_APPS_PATH:-./data/apps-extra}:/var/www/html/apps-shared'
+      - '${STABLE_ROOT_PATH}/stable31/apps-writable:/var/www/html/apps-writable'
       - /var/www/html/data
       - /var/www/html/config
-      - /var/www/html/apps-writable
       - ./data/skeleton/:/skeleton
       - ./data/additional.config.php:/var/www/html/config/additional.config.php:ro
       - ./data/shared:/shared
@@ -649,9 +649,9 @@ services:
       - '${STABLE_ROOT_PATH}/stable32:/var/www/html'
       - '${STABLE_ROOT_PATH}/stable32/apps-extra:/var/www/html/apps-extra'
       - '${ADDITIONAL_APPS_PATH:-./data/apps-extra}:/var/www/html/apps-shared'
+      - '${STABLE_ROOT_PATH}/stable31/apps-writable:/var/www/html/apps-writable'
       - /var/www/html/data
       - /var/www/html/config
-      - /var/www/html/apps-writable
       - ./data/skeleton/:/skeleton
       - ./data/additional.config.php:/var/www/html/config/additional.config.php:ro
       - ./data/shared:/shared
@@ -794,7 +794,7 @@ services:
       - "${IP_BIND:-127.0.0.1}:${PORTBASE:-800}8:80"
 
   saml:
-    image: unicon/simplesamlphp 
+    image: unicon/simplesamlphp
     volumes:
       - ./docker/configs/var-simplesamlphp/config:/var/simplesamlphp/config
       - ./docker/configs/var-simplesamlphp/cert:/var/simplesamlphp/cert


### PR DESCRIPTION
Hello Team, 

Here's a little PR that could make DX better :

### Problem

When using `nextcloud-docker-dev` for local development, apps installed via
`occ app:install` or the App Store were not appearing on the host filesystem.

Although bind-mounts for app directories were defined, they were overridden
by anonymous Docker volumes declared later in the service configuration.
As a result, Nextcloud was writing apps into anonymous volumes instead of
the intended local directories, making them invisible to IDEs.

### Root cause

Docker gives precedence to the last volume mounted on a given path.
Anonymous volumes declared for:

- `/var/www/html/apps-writable`

were overriding explicit bind-mounts for development.

### Solution

This PR removes the anonymous volumes that shadow bind-mounted directories.
With this change:

- Apps installed via App Store or `occ` are written to the bind-mounted
  `apps-writable` directory
- Installed apps are immediately visible on the host filesystem
- The development workflow works as expected without manual workarounds

### Impact

- No impact on production usage (dev-only setup)
- Improves developer experience and avoids confusing behavior
- Aligns container filesystem behavior with expectations when using bind-mounts
