### PR TITLE
chore: add stable33 support

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,7 +82,7 @@ if [ -f ".env" ]; then
 		echo "❌ Repository path does not exist"
 	fi
 
-	for i in stable28 stable29 stable30 stable31 stable32
+	for i in stable29 stable30 stable31 stable32 stable33
 	do
 		echo "Stable $i repository path: ${STABLE_ROOT_PATH}/${i}"
 		STABLE_VERSION=$(grep "OC_VersionString" "${STABLE_ROOT_PATH}/${i}/version.php" | cut -d "'" -f 2)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
           - stable30${DOMAIN_SUFFIX}
           - stable31${DOMAIN_SUFFIX}
           - stable32${DOMAIN_SUFFIX}
+          - stable33${DOMAIN_SUFFIX}
           - mail${DOMAIN_SUFFIX}
           - sso${DOMAIN_SUFFIX}
           - minio${DOMAIN_SUFFIX}
@@ -663,6 +664,36 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
 
+  stable33:
+    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-83}:latest
+    environment:
+      SQL: ${SQL:-mysql}
+      NEXTCLOUD_AUTOINSTALL: "YES"
+      NEXTCLOUD_AUTOINSTALL_APPS:
+      WITH_REDIS: "YES"
+      VIRTUAL_HOST: stable33${DOMAIN_SUFFIX}
+      ADDITIONAL_APPS_PATH:
+      NEXTCLOUD_TRUSTED_DOMAINS:
+      PRIMARY: ${PRIMARY:-local}
+      PHP_XDEBUG_MODE: ${PHP_XDEBUG_MODE:-develop}
+    volumes:
+      - '${STABLE_ROOT_PATH}/stable33:/var/www/html'
+      - '${STABLE_ROOT_PATH}/stable33/apps-extra:/var/www/html/apps-extra'
+      - '${ADDITIONAL_APPS_PATH:-./data/apps-extra}:/var/www/html/apps-shared'
+      - /var/www/html/data
+      - /var/www/html/config
+      - /var/www/html/apps-writable
+      - ./data/skeleton/:/skeleton
+      - ./data/additional.config.php:/var/www/html/config/additional.config.php:ro
+      - ./data/shared:/shared
+    depends_on:
+      - database-${SQL:-mysql}
+      - redis
+      - mail
+      - ${PROXY_SERVICE:-proxy}
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
   database-sqlite:
     image: ghcr.io/juliusknorr/nextcloud-dev-noop:latest
 
@@ -866,6 +897,7 @@ services:
       aliasgroup11: http://stable30${DOMAIN_SUFFIX}
       aliasgroup12: http://stable31${DOMAIN_SUFFIX}
       aliasgroup13: http://stable32${DOMAIN_SUFFIX}
+      aliasgroup14: http://stable33${DOMAIN_SUFFIX}
       dictionaries: de_DE en_US en_GB
       username: admin
       password: admin


### PR DESCRIPTION
Note: PHP version is set to 8.3 as the oldest non-deprecated