### PR TITLE
fix: add default database name

### DIFF
--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -227,7 +227,11 @@ configure_add_user() {
 
 
 install() {
-	DBNAME=$(echo "$VIRTUAL_HOST" | cut -d '.' -f1)
+	if [ -n "$VIRTUAL_HOST" ]; then
+		DBNAME=$(echo "$VIRTUAL_HOST" | cut -d '.' -f1)
+	else
+		DBNAME="nextcloud"
+	fi
 	SQLHOST="database-$SQL"
 	echo "database name will be $DBNAME"
 


### PR DESCRIPTION
env `VIRTUAL_HOST` is used to determine the database name, and if `VIRTUAL_HOST` is not set while running the container with `SQL=mysql` and `NEXTCLOUD_AUTOINSTALL=YES`, the nextcloud installation fails because the `--database-name=` option has empty value

command:
```bash
# start mysql server
# start nextcloud
docker run --rm \
-e SERVER_BRANCH=stable32 \
-e NEXTCLOUD_AUTOINSTALL=true \
-e SQL=mysql \
ghcr.io/juliusknorr/nextcloud-dev-php84:master
```
```
⌛ Waiting for other containers
 - MySQL
✅ Database server ready
⚠ No value for PHP_XDEBUG_MODE was found. Not updating the setting.
Nextcloud is not installed - only a limited number of commands are available
Add the host IP as host.docker.internal to /etc/hosts ...
database name will be 
🔧 Starting auto installation
occ maintenance:install --admin-user=admin --admin-pass=admin --database=mysql --database-name= --database-host=database-mysql --database-user=root --database-pass=nextcloud
   Enter the database name for MySQL/MariaDB
Nextcloud is not installed - only a limited number of commands are available
Last nextcloud.log entry:

=======================================================================================
🚨 Server installation failed.
=======================================================================================
```