### PR TITLE
fix(s3): adjust rustfs setup documentation

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -27,15 +27,20 @@ PRIMARY=rustfs docker compose up nextcloud rustfs
 
 ### External object storage
 
-External storage can be configured in the Nextcloud admin settings. This is an example configuration for the `nc-external` bucket, buckets will be autocreated so you can name any bucket you like:
+External storage can be configured in the Nextcloud admin settings (configuration labels may depend on app version).
+This is an example configuration for the `nc-external` bucket, buckets will be automatically created so you can name any bucket you like:
 
+General:
+- External storage: `S3 Storage`
+- Authentication: `Static credentials` / `Access Key`
+Storage configuration:
 - Bucket: `nc-external`
-- Authentication: `Access Key`
 - Hostname: `rustfs`
 - Port: `9000`
 - Enable SSL: `No`
 - Enable Path Style: `Yes`
-- Legacy (v2) Authentication: `No`
+- Use Legacy S3 signing (v2) / Legacy (v2) Authentication: `No`
+Authentication:
 - Access Key: `nextcloud`
 - Secret Key: `nextcloud`
 


### PR DESCRIPTION
- some labels have changed in files_external 1.25.1 -> 1.26.0, had trouble finding them

<img width="209" height="529" alt="image" src="https://github.com/user-attachments/assets/0462e7a3-49f7-4baf-bf10-09bbc31571e7" /><img width="211" height="534" alt="image" src="https://github.com/user-attachments/assets/d8f82b1e-acfd-4a0b-82f1-bd82e90c3028" />

