### PR TITLE
fix: switch shebang to /usr/bin/env bash

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2181
 
 # set -o xtrace

--- a/docker/keycloak/prepare.sh
+++ b/docker/keycloak/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KEYCLOAK_REALM_CONFIG="/opt/keycloak/data/import/Example-realm.json"
 PROTOCOL="${PROTOCOL:-http}"

--- a/docs/customizing/hooks.md
+++ b/docs/customizing/hooks.md
@@ -12,7 +12,7 @@ The following hooks are currently available:
 ## Example for after-install.sh
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo 'Create some users'
 export OC_PASS=mycustomuser
@@ -22,7 +22,7 @@ occ user:add --password-from-env mycustomuser
 ## Example for before-start.sh
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo 'Always disable the firstrunwizard'
 occ app:disable firstrunwizard

--- a/scripts/download-full-history.sh
+++ b/scripts/download-full-history.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 isShallow() {
     # Reference: https://stackoverflow.com/a/37533086

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function get_docker_compose_command() {
     docker-compose version >/dev/null 2>/dev/null && DCC='docker-compose'

--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)

--- a/scripts/occ.sh
+++ b/scripts/occ.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)

--- a/scripts/php-mod-config
+++ b/scripts/php-mod-config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)

--- a/scripts/update-certs
+++ b/scripts/update-certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)

--- a/scripts/update-hosts
+++ b/scripts/update-hosts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)


### PR DESCRIPTION
This makes it easier to use this project on NixOS (as discussed in #429). Similar commit is already in #428 but I'm submitting it separately in hopes that this would make it easier to merge.