### PR TITLE
fix: correct host field in AppAPI docs

### DIFF
--- a/docs/services/app_api.md
+++ b/docs/services/app_api.md
@@ -14,7 +14,7 @@ docker compose up -d appapi-dsp
 
 After the DSP container is running, configure the Deploy daemon in AppAPI admin settings with the following parameters:
 
-- **Host**: `http://nextcloud-appapi-dsp-http:2375`
+- **Host**: `nextcloud-appapi-dsp-http:2375`
 - **Nextcloud URL**: `http://nextcloud.local` (locally always use http)
 - **Enable https**: `false`
 - **Network**: `master_default` (the network of nextcloud-docker-dev docker-compose, by default it is `master_default`)
@@ -47,7 +47,7 @@ docker compose up -d appapi-dsp-https
 
 After the DSP container is running and the certificate is imported in Nextcloud, configure the Deploy daemon in AppAPI admin settings with the following parameters:
 
-- **Host**: `https://<nextcloud-appapi-dsp-https or BIND_ADDRESS IP>:2375` (use host depending on your setup)
+- **Host**: `<nextcloud-appapi-dsp-https or BIND_ADDRESS IP>:2375` (use host depending on your setup)
 - **Nextcloud URL**: `http://nextcloud.local` (locally always use http)
 - **Enable https**: `true`
 - **Network**: `host` (with https enabled, the network is forced to `host`)


### PR DESCRIPTION
The host field in AppAPI settings shouldn't include protocol. I'm using this repo to setup docker with AppAPI in docker and I'm getting the following error from NextCloud when I try to configure a deploy daemon with protocol:
```
cURL error 6: Could not resolve host: http (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://http//nextcloud-appapi-dsp-http:2375/v1.41/_ping
```
Without the protocol I'm able to connect successfully.