### PR TITLE
Fix/fts address for CORS allow origin and map port on host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -974,8 +974,9 @@ services:
       - VIRTUAL_HOST=elasticsearch${DOMAIN_SUFFIX}
       - VIRTUAL_PORT=9200
       - VIRTUAL_PROTO=http
+    ports:
+      - "9200:9200"
     expose:
-      - 9200
       - 9300
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -965,7 +965,7 @@ services:
       - discovery.type=single-node
       - http.port=9200
       - http.cors.enabled=true
-      - http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358,http://elasticsearch-ui.dev.local
+      - http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358,http://elasticsearch-ui${DOMAIN_SUFFIX}
       - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       - http.cors.allow-credentials=true
       - bootstrap.memory_lock=true


### PR DESCRIPTION

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI

### Summary

This PR:
  - Removes `.dev` from the CORS allow origin policy, as this setup uses `.local` only
  - Maps `elasticsearch` port `9200` to `9200` on the host, so that `elasticsearch-ui` and any other HTTP client can reach elasticsearch for debugging purposes.