### PR TITLE
chore: migrate repo references from juliusknorr to nextcloud org

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
   push_to_registry:
     name: Build image
     runs-on: ubuntu-latest
-    if: github.repository == 'juliusknorr/nextcloud-docker-dev'
+    if: github.repository == 'nextcloud/nextcloud-docker-dev'
     strategy:
       fail-fast: false
       matrix:
@@ -82,8 +82,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
           tags: |
-            ghcr.io/juliusknorr/nextcloud-dev-${{ matrix.container }}:${{ github.sha }}
-            ghcr.io/juliusknorr/nextcloud-dev-${{ matrix.container }}:latest
+            ghcr.io/nextcloud/nextcloud-dev-${{ matrix.container }}:${{ github.sha }}
+            ghcr.io/nextcloud/nextcloud-dev-${{ matrix.container }}:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Push container image
@@ -95,8 +95,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
           tags: |
-            ghcr.io/juliusknorr/nextcloud-dev-${{ matrix.container }}:${{ github.event_name == 'release' && 'release' || 'latest' }}
-            ghcr.io/juliusknorr/nextcloud-dev-${{ matrix.container }}:${{ github.ref_name }}
+            ghcr.io/nextcloud/nextcloud-dev-${{ matrix.container }}:${{ github.event_name == 'release' && 'release' || 'latest' }}
+            ghcr.io/nextcloud/nextcloud-dev-${{ matrix.container }}:${{ github.ref_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Start containers with docker compose

--- a/Makefile
+++ b/Makefile
@@ -9,29 +9,29 @@ images: docker/*/Dockerfile docker/Dockerfile.*
 pull-all:
 	for file in $$(find docker/ -maxdepth 1 -type f -iname 'Dockerfile.*'); do \
 		NAME=$$(echo $$file | sed 's/^.*\.//'); \
-		echo "=> Pulling image $$NAME"; docker pull "ghcr.io/juliusknorr/nextcloud-dev-$${NAME}"; \
+		echo "=> Pulling image $$NAME"; docker pull "ghcr.io/nextcloud/nextcloud-dev-$${NAME}"; \
 	done
 	for file in $$(find docker -maxdepth 2 -type f -iname 'Dockerfile'); do \
 		NAME=$$(basename $$(dirname $$file)); \
-		echo "=> Pulling image $$NAME"; docker pull "ghcr.io/juliusknorr/nextcloud-dev-$${NAME}"; \
+		echo "=> Pulling image $$NAME"; docker pull "ghcr.io/nextcloud/nextcloud-dev-$${NAME}"; \
 	done
 
 pull-installed:
-	docker image ls | grep juliusknorr/nextcloud-dev | cut -f 1 -d " "
-	docker image ls | grep juliusknorr/nextcloud-dev | cut -f 1 -d " " | xargs -L 1 docker pull
+	docker image ls | grep nextcloud/nextcloud-dev | cut -f 1 -d " "
+	docker image ls | grep nextcloud/nextcloud-dev | cut -f 1 -d " " | xargs -L 1 docker pull
 
 # Empty target to always build
 docker-build:
 
 docker/%/Dockerfile: docker-build
 	NAME=$$(basename $$(dirname $@)); \
-	echo "=> Building dockerfile" $@ as ghcr.io/juliusknorr/nextcloud-dev-$$NAME:latest; \
-	(cd docker && docker build -t ghcr.io/juliusknorr/nextcloud-dev-$$NAME:latest -f $$NAME/Dockerfile .)
+	echo "=> Building dockerfile" $@ as ghcr.io/nextcloud/nextcloud-dev-$$NAME:latest; \
+	(cd docker && docker build -t ghcr.io/nextcloud/nextcloud-dev-$$NAME:latest -f $$NAME/Dockerfile .)
 
 docker/Dockerfile.%: docker-build
 	NAME=$$(echo $$(basename $@) | sed 's/^.*\.//'); \
-	echo "=> Building dockerfile" $@ as ghcr.io/juliusknorr/nextcloud-dev-$$NAME:latest; \
-	(cd docker && docker build -t ghcr.io/juliusknorr/nextcloud-dev-$$NAME:latest -f Dockerfile.$$NAME .)
+	echo "=> Building dockerfile" $@ as ghcr.io/nextcloud/nextcloud-dev-$$NAME:latest; \
+	(cd docker && docker build -t ghcr.io/nextcloud/nextcloud-dev-$$NAME:latest -f Dockerfile.$$NAME .)
 
 check: dockerfilelint shellcheck
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nextcloud development environment on Docker Compose
 
-[Documentation](https://juliusknorr.github.io/nextcloud-docker-dev/) | [Nextcloud Developer Portal](https://nextcloud.com/developer/)
+[Documentation](https://nextcloud.github.io/nextcloud-docker-dev/) | [Nextcloud Developer Portal](https://nextcloud.com/developer/)
 
 Nextcloud's development environment using Docker Compose providing a large variety of services for Nextcloud server and app development and testing.
 
@@ -20,7 +20,7 @@ Nextcloud's development environment using Docker Compose providing a large varie
 
 You can find a step-by-step tutorial on how to use this setup in the [Nextcloud Developer Portal](https://nextcloud.com/developer/). It will guide you through the setup and show you how to use it for app development: https://cloud.nextcloud.com/s/iyNGp8ryWxc7Efa?path=%2F1%20Setting%20up%20a%20development%20environment
 
-In detail explanation of the setup and its features and configuration options can be found in the [nextcloud-docker-dev documentation](https://juliusknorr.github.io/nextcloud-docker-dev/).
+In detail explanation of the setup and its features and configuration options can be found in the [nextcloud-docker-dev documentation](https://nextcloud.github.io/nextcloud-docker-dev/).
 
 ## Quickstart
 
@@ -31,7 +31,7 @@ In detail explanation of the setup and its features and configuration options ca
 
 To start the setup run the following commands to clone the repository and bootstrap the setup. This will prepare your setup and clone the Nextcloud server repository and required apps into the `workspace` folder.
 ```bash
-git clone https://github.com/juliusknorr/nextcloud-docker-dev
+git clone https://github.com/nextcloud/nextcloud-docker-dev
 cd nextcloud-docker-dev
 ./bootstrap.sh
 ```
@@ -47,7 +47,7 @@ docker compose up nextcloud
 
 You can also start it in the background using `docker compose up -d nextcloud`.
 
-You can then access your Nextcloud instance at [http://nextcloud.local](http://nextcloud.local). The default username is `admin` and the password is `admin`. [Other users can be found in the documentation](https://juliusknorr.github.io/nextcloud-docker-dev/basics/overview/#default-users).
+You can then access your Nextcloud instance at [http://nextcloud.local](http://nextcloud.local). The default username is `admin` and the password is `admin`. [Other users can be found in the documentation](https://nextcloud.github.io/nextcloud-docker-dev/basics/overview/#default-users).
 
 > [!WARN]
 > Note that for performance reasons the server repository might have been cloned with `--depth=1` by default. To get the full history it is highly recommended to run:
@@ -74,29 +74,29 @@ Running the containers does not need this repository to be cloned.
 Example for running a Nextcloud server from the master branch of server:
 
 ```bash
-docker run --rm -p 8080:80 ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 
 For app development you can mount your app directly into the container:
 
 ```bash
-docker run --rm -p 8080:80 -v ~/path/to/appid:/var/www/html/apps-extra/appid ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 -v ~/path/to/appid:/var/www/html/apps-extra/appid ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 
 The `SERVER_BRANCH` environment variable can be used to run different versions of Nextcloud by specifying either a server branch or git tag.
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 
 You can also mount your local server source code into the container to run a local version of Nextcloud:
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 ## More features
 
-You can find documentation for more advanced features in [nextcloud-docker-dev documentation](https://juliusknorr.github.io/nextcloud-docker-dev/) for example:
+You can find documentation for more advanced features in [nextcloud-docker-dev documentation](https://nextcloud.github.io/nextcloud-docker-dev/) for example:
 
 - Running stable Nextcloud versions in parallel
 - Using different database backends

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -295,5 +295,5 @@ cat <<EOF
 
 For more details about the individual setup options see
 the README.md file or checkout the repo at
-https://github.com/juliusknorr/nextcloud-docker-dev
+https://github.com/nextcloud/nextcloud-docker-dev
 EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Proxy for ssl termination and easier hostname access
   # SSL certificates with the virtual host name need to be added to ./data/ssl
   proxy:
-    image: ghcr.io/juliusknorr/nextcloud-dev-nginx:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-nginx:latest
     ports:
       - "${IP_BIND:-127.0.0.1}:${PROXY_PORT_HTTP:-80}:80"
       - "${IP_BIND:-127.0.0.1}:${PROXY_PORT_HTTPS:-443}:443"
@@ -80,7 +80,7 @@ services:
       - ./docker/configs/haproxy.conf:/usr/local/etc/haproxy/haproxy.cfg:ro
 
   nextcloud:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-85}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-85}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: ${NEXTCLOUD_AUTOINSTALL:-YES}
@@ -113,7 +113,7 @@ services:
       - host.docker.internal:host-gateway
 
   nextcloud2:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-85}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-85}:latest
     environment:
       SQL: ${SQL:-mysql}
       VIRTUAL_HOST: "nextcloud2${DOMAIN_SUFFIX}"
@@ -140,7 +140,7 @@ services:
       - host.docker.internal:host-gateway
 
   nextcloud3:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-85}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-85}:latest
     environment:
       SQL: ${SQL:-mysql}
       VIRTUAL_HOST: "nextcloud3${DOMAIN_SUFFIX}"
@@ -165,7 +165,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable16:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-73}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-73}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -195,7 +195,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable17:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-73}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-73}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -225,7 +225,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable18:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-74}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-74}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -255,7 +255,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable19:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-74}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-74}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -285,7 +285,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable20:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-74}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-74}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -315,7 +315,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable21:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-80}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-80}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -346,7 +346,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable22:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-80}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-80}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -377,7 +377,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable23:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-80}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-80}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -408,7 +408,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable24:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-80}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-80}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -439,7 +439,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable25:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -470,7 +470,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable26:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -501,7 +501,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable27:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -532,7 +532,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable28:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -563,7 +563,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable29:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -594,7 +594,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable30:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -625,7 +625,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable31:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -656,7 +656,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable32:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -687,7 +687,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable33:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-83}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-83}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -718,7 +718,7 @@ services:
       - host.docker.internal:host-gateway
 
   stable34:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-83}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-83}:latest
     environment:
       SQL: ${SQL:-mysql}
       NEXTCLOUD_AUTOINSTALL: "YES"
@@ -749,7 +749,7 @@ services:
       - host.docker.internal:host-gateway
 
   database-sqlite:
-    image: ghcr.io/juliusknorr/nextcloud-dev-noop:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-noop:latest
 
   database-mysql:
     image: mariadb:10.6
@@ -890,7 +890,7 @@ services:
       - 80
 
   mail:
-    image: ghcr.io/juliusknorr/nextcloud-dev-mailhog:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-mailhog:latest
     environment:
       VIRTUAL_HOST: "mail${DOMAIN_SUFFIX}"
       VIRTUAL_PORT: 8025
@@ -1049,7 +1049,7 @@ services:
 
 
   push:
-    image: ghcr.io/juliusknorr/nextcloud-dev-push:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-push:latest
     environment:
       RUST_LOG: debug
       VIRTUAL_HOST: push${DOMAIN_SUFFIX}
@@ -1059,7 +1059,7 @@ services:
       NEXTCLOUD_URL: http://nextcloud
 
   keycloak:
-    image: ghcr.io/juliusknorr/nextcloud-dev-keycloak:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-keycloak:latest
     expose:
       - 8080
     # volumes:
@@ -1084,7 +1084,7 @@ services:
       - clam:/var/lib/clamav
 
   portal:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       VIRTUAL_HOST: portal${DOMAIN_SUFFIX}
       SQL: 'mysql'
@@ -1109,7 +1109,7 @@ services:
       - host.docker.internal:host-gateway
 
   gs1:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: 'mysql'
       NEXTCLOUD_AUTOINSTALL: ${NEXTCLOUD_AUTOINSTALL:-YES}
@@ -1139,7 +1139,7 @@ services:
       - host.docker.internal:host-gateway
 
   gs2:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: 'mysql'
       NEXTCLOUD_AUTOINSTALL: ${NEXTCLOUD_AUTOINSTALL:-YES}
@@ -1169,7 +1169,7 @@ services:
       - host.docker.internal:host-gateway
 
   gs3:
-    image: ghcr.io/juliusknorr/nextcloud-dev-php${PHP_VERSION:-82}:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-php${PHP_VERSION:-82}:latest
     environment:
       SQL: 'mysql'
       NEXTCLOUD_AUTOINSTALL: ${NEXTCLOUD_AUTOINSTALL:-YES}
@@ -1199,7 +1199,7 @@ services:
       - host.docker.internal:host-gateway
 
   lookup:
-    image: ghcr.io/juliusknorr/nextcloud-dev-lookupserver:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-lookupserver:latest
     environment:
       VIRTUAL_HOST: "lookup${DOMAIN_SUFFIX}"
       PROTOCOL: ${PROTOCOL:-https}
@@ -1254,7 +1254,7 @@ services:
       INTERNAL_SHARED_SECRET_KEY: "4567"
 
   talk-janus:
-    image: ghcr.io/juliusknorr/nextcloud-dev-talk-janus:latest
+    image: ghcr.io/nextcloud/nextcloud-dev-talk-janus:latest
 
   talk-recording:
     image: ghcr.io/nextcloud-releases/aio-talk-recording:latest

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -13,7 +13,7 @@ There are two ways of using this setup. **A persistent setup is the most common 
 
 To start the setup run the following commands to clone the repository and bootstrap the setup. This will prepare your setup and clone the Nextcloud server repository and required apps into the `workspace` folder.
 ```bash
-git clone https://github.com/juliusknorr/nextcloud-docker-dev
+git clone https://github.com/nextcloud/nextcloud-docker-dev
 cd nextcloud-docker-dev
 ./bootstrap.sh
 ```
@@ -32,7 +32,7 @@ docker compose up nextcloud
 
 You can also start it in the background using `docker compose up -d nextcloud`.
 
-You can then access your Nextcloud instance at [http://nextcloud.local](http://nextcloud.local). The default username is `admin` and the password is `admin`. [Other users can be found in the documentation](https://juliusknorr.github.io/nextcloud-docker-dev/basics/overview/#default-users).
+You can then access your Nextcloud instance at [http://nextcloud.local](http://nextcloud.local). The default username is `admin` and the password is `admin`. [Other users can be found in the documentation](https://nextcloud.github.io/nextcloud-docker-dev/basics/overview/#default-users).
 
 !!! warning
     Note that for performance reasons the server repository might have been cloned with `--depth=1` by default. To get the full history it is highly recommended to run:
@@ -59,23 +59,23 @@ Running the containers does not need this repository to be cloned.
 Example for running a Nextcloud server from the master branch of server:
 
 ```bash
-docker run --rm -p 8080:80 ghcr.io/juliusknorr/nextcloud-dev-php80:latest
+docker run --rm -p 8080:80 ghcr.io/nextcloud/nextcloud-dev-php80:latest
 ```
 
 For app development you can mount your app directly into the container:
 
 ```bash
-docker run --rm -p 8080:80 -v ~/path/to/appid:/var/www/html/apps-extra/appid ghcr.io/juliusknorr/nextcloud-dev-php80:latest
+docker run --rm -p 8080:80 -v ~/path/to/appid:/var/www/html/apps-extra/appid ghcr.io/nextcloud/nextcloud-dev-php80:latest
 ```
 
 The `SERVER_BRANCH` environment variable can be used to run different versions of Nextcloud by specifying either a server branch or git tag.
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/juliusknorr/nextcloud-dev-php80:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 ghcr.io/nextcloud/nextcloud-dev-php80:latest
 ```
 
 You can also mount your local server source code into the container to run a local version of Nextcloud:
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/juliusknorr/nextcloud-dev-php80:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v24.0.1 -v /tmp/server:/var/www/html ghcr.io/nextcloud/nextcloud-dev-php80:latest
 ```

--- a/docs/basics/standalone.md
+++ b/docs/basics/standalone.md
@@ -9,7 +9,7 @@ Running the containers does not need this repository to be cloned.
 Example for running a Nextcloud server from the master branch of server:
 
 ```bash
-docker run --rm -p 8080:80 ghcr.io/juliusknorr/nextcloud-dev-php80:latest
+docker run --rm -p 8080:80 ghcr.io/nextcloud/nextcloud-dev-php80:latest
 ```
 
 For app development you can mount your app directly into the container:
@@ -17,17 +17,17 @@ For app development you can mount your app directly into the container:
 ```bash
 docker run --rm -p 8080:80 \
     -v ~/path/to/appid:/var/www/html/apps-extra/appid \
-    ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+    ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 
 The `SERVER_BRANCH` environment variable can be used to run different versions of Nextcloud by specifying either a server branch or git tag.
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v32.0.1 ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v32.0.1 ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```
 
 You can also mount your local server source code into the container to run a local version of Nextcloud:
 
 ```bash
-docker run --rm -p 8080:80 -e SERVER_BRANCH=v32.0.1 -v /tmp/server:/var/www/html ghcr.io/juliusknorr/nextcloud-dev-php81:latest
+docker run --rm -p 8080:80 -e SERVER_BRANCH=v32.0.1 -v /tmp/server:/var/www/html ghcr.io/nextcloud/nextcloud-dev-php81:latest
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,4 +14,4 @@ Various settings in this setup are considered insecure and default passwords and
 - 🚀 Blackfire, Xdebug for profiling and debugging
 - 📄 Lots of integrating service containers: Collabora Online, Onlyoffice, Elasticsearch, ...
 
-Follow the [getting started guide](https://juliusknorr.github.io/nextcloud-docker-dev/basics/getting-started/) or the [Nextcloud developer tutorial](https://nextcloud.com/developer/) to get started.
+Follow the [getting started guide](https://nextcloud.github.io/nextcloud-docker-dev/basics/getting-started/) or the [Nextcloud developer tutorial](https://nextcloud.com/developer/) to get started.

--- a/docs/services/ldap.md
+++ b/docs/services/ldap.md
@@ -1,6 +1,6 @@
 # LDAP
 
-The LDAP sample data is based on <https://github.com/rroemhild/docker-test-openldap> and extended with randomly generated users/groups. For details see [data/ldap-generator/](https://github.com/juliusknorr/nextcloud-docker-dev/tree/master/data/ldap-generator). LDAP will be configured automatically if the ldap container is available during installation.
+The LDAP sample data is based on <https://github.com/rroemhild/docker-test-openldap> and extended with randomly generated users/groups. For details see [data/ldap-generator/](https://github.com/nextcloud/nextcloud-docker-dev/tree/master/data/ldap-generator). LDAP will be configured automatically if the ldap container is available during installation.
 
 Example users are: `leela fry bender zoidberg hermes professor`. The password is the same as the uid.
 


### PR DESCRIPTION
## Summary

- Replace all `juliusknorr` references with `nextcloud` across the codebase
- Updates GitHub repo URLs (`github.com/juliusknorr/` → `github.com/nextcloud/`)
- Updates GitHub Pages docs URLs (`juliusknorr.github.io/` → `nextcloud.github.io/`)
- Updates container image references (`ghcr.io/juliusknorr/` → `ghcr.io/nextcloud/`)
- Updates the CI workflow repo guard condition so image builds publish to the new namespace

## Note on container images

The `ghcr.io/nextcloud/` images don't exist yet — they will be published automatically once the updated `docker.yml` workflow runs on this repo. A Nextcloud org admin will need to trigger or merge this and run a build to populate the new image namespace.

## Test plan

- [ ] Verify `grep -r juliusknorr .` returns no results after merge
- [ ] Trigger the Docker build workflow to confirm images publish to `ghcr.io/nextcloud/`
- [ ] Confirm docs site is live at `https://nextcloud.github.io/nextcloud-docker-dev/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)