### PR TITLE
fix(ldap): extract config set to standalone script

### DIFF
--- a/docker/Dockerfile.php.template
+++ b/docker/Dockerfile.php.template
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php71
+++ b/docker/Dockerfile.php71
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php72
+++ b/docker/Dockerfile.php72
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php73
+++ b/docker/Dockerfile.php73
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php74
+++ b/docker/Dockerfile.php74
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php80
+++ b/docker/Dockerfile.php80
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/Dockerfile.php81
+++ b/docker/Dockerfile.php81
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/bin/bootstrap.sh
+++ b/docker/bin/bootstrap.sh
@@ -226,34 +226,7 @@ configure_ldap() {
 		return 0
 	fi
 
-	timeout 5 bash -c 'until echo > /dev/tcp/ldap/389; do sleep 0.5; done' 2>/dev/null
-	if [ $? -eq 0 ]; then
-		output "LDAP server available"
-		export LDAP_USER_FILTER="(|(objectclass=inetOrgPerson))"
-
-		OCC app:enable user_ldap
-		OCC ldap:create-empty-config
-		OCC ldap:set-config s01 ldapAgentName "cn=admin,dc=planetexpress,dc=com"
-		OCC ldap:set-config s01 ldapAgentPassword "admin"
-		OCC ldap:set-config s01 ldapAttributesForUserSearch "sn;givenname"
-		OCC ldap:set-config s01 ldapBase "dc=planetexpress,dc=com"
-		OCC ldap:set-config s01 ldapEmailAttribute "mail"
-		OCC ldap:set-config s01 ldapExpertUsernameAttr "uid"
-		OCC ldap:set-config s01 ldapGroupDisplayName "description"
-		OCC ldap:set-config s01 ldapGroupFilter '(|(objectclass=groupOfNames))'
-		OCC ldap:set-config s01 ldapGroupFilterObjectclass 'groupOfNames'
-		OCC ldap:set-config s01 ldapGroupMemberAssocAttr 'member'
-		OCC ldap:set-config s01 ldapHost 'ldap'
-		OCC ldap:set-config s01 ldapLoginFilter "(&$LDAP_USER_FILTER(uid=%uid))"
-		OCC ldap:set-config s01 ldapLoginFilterMode '1'
-		OCC ldap:set-config s01 ldapLoginFilterUsername '1'
-		OCC ldap:set-config s01 ldapPort '389'
-		OCC ldap:set-config s01 ldapTLS '0'
-		OCC ldap:set-config s01 ldapUserDisplayName 'cn'
-		OCC ldap:set-config s01 ldapUserFilter "$LDAP_USER_FILTER"
-		OCC ldap:set-config s01 ldapUserFilterMode "1"
-		OCC ldap:set-config s01 ldapConfigurationActive "1"
-	fi
+	configure-ldap.sh
 }
 
 configure_oidc() {

--- a/docker/bin/configure-ldap.sh
+++ b/docker/bin/configure-ldap.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Configure the user_ldap app against the bundled `ldap` service.
+#
+# Reused in two places:
+#   - docker/bin/bootstrap.sh, during the install/bootstrap phase
+#   - on demand against a running container:
+#       docker compose exec <container> configure-ldap.sh
+#
+# Relies on the in-container `occ` wrapper (/usr/local/bin/occ) and the
+# WEBROOT env var, both provided by the image.
+
+# Wait for the ldap server to accept connections before configuring.
+timeout 5 bash -c 'until echo > /dev/tcp/ldap/389; do sleep 0.5; done' 2>/dev/null
+if [ $? -ne 0 ]; then
+	echo "LDAP server (ldap:389) not available; skipping LDAP configuration"
+	exit 0
+fi
+
+echo "LDAP server available"
+LDAP_USER_FILTER="(|(objectclass=inetOrgPerson))"
+
+occ app:enable user_ldap
+occ ldap:create-empty-config
+occ ldap:set-config s01 ldapAgentName "cn=admin,dc=planetexpress,dc=com"
+occ ldap:set-config s01 ldapAgentPassword "admin"
+occ ldap:set-config s01 ldapAttributesForUserSearch "sn;givenname"
+occ ldap:set-config s01 ldapBase "dc=planetexpress,dc=com"
+occ ldap:set-config s01 ldapEmailAttribute "mail"
+occ ldap:set-config s01 ldapExpertUsernameAttr "uid"
+occ ldap:set-config s01 ldapGroupDisplayName "description"
+occ ldap:set-config s01 ldapGroupFilter '(|(objectclass=groupOfNames))'
+occ ldap:set-config s01 ldapGroupFilterObjectclass 'groupOfNames'
+occ ldap:set-config s01 ldapGroupMemberAssocAttr 'member'
+occ ldap:set-config s01 ldapHost 'ldap'
+occ ldap:set-config s01 ldapLoginFilter "(&$LDAP_USER_FILTER(uid=%uid))"
+occ ldap:set-config s01 ldapLoginFilterMode '1'
+occ ldap:set-config s01 ldapLoginFilterUsername '1'
+occ ldap:set-config s01 ldapPort '389'
+occ ldap:set-config s01 ldapTLS '0'
+occ ldap:set-config s01 ldapUserDisplayName 'cn'
+occ ldap:set-config s01 ldapUserFilter "$LDAP_USER_FILTER"
+occ ldap:set-config s01 ldapUserFilterMode "1"
+occ ldap:set-config s01 ldapConfigurationActive "1"

--- a/docker/php82/Dockerfile
+++ b/docker/php82/Dockerfile
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/php83/Dockerfile
+++ b/docker/php83/Dockerfile
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/php84/Dockerfile
+++ b/docker/php84/Dockerfile
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/docker/php85/Dockerfile
+++ b/docker/php85/Dockerfile
@@ -105,4 +105,4 @@ CMD ["apache2-foreground"]
 
 ADD data/installing.html /root/installing.html
 ADD configs/autoconfig_mysql.php configs/autoconfig_pgsql.php configs/autoconfig_oci.php configs/default.config.php configs/redis.config.php configs/apcu.config.php /root/
-ADD bin/bootstrap.sh bin/occ /usr/local/bin/
+ADD bin/bootstrap.sh bin/occ bin/configure-ldap.sh /usr/local/bin/

--- a/scripts/enable-ldap.sh
+++ b/scripts/enable-ldap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+# shellcheck source=example.env
+source "${SCRIPT_DIR}/../.env"
+# shellcheck source=scripts/functions.sh
+source "${SCRIPT_DIR}/functions.sh"
+
+if [ -z "$1" ]
+  then
+    echo "Usage $0 CONTAINER"
+	exit 1
+fi
+
+CONTAINER=$1
+
+echo "Configuring LDAP on $CONTAINER"
+docker_compose up -d ldap ldapadmin
+docker_compose exec "$CONTAINER" configure-ldap.sh


### PR DESCRIPTION
Extract ldap configuration from bootstrap.sh to standalone script
- allows to set ldap during bootstrap, but also later when instance is up and running
- add new script to Dockerfile
 - Needs image rebuild?


To test:
```bash
docker compose up -d nextcloud proxy
# optional to not rebuild
docker compose cp docker/bin/configure-ldap.sh nextcloud:/usr/local/bin/configure-ldap.sh
docker compose exec nextcloud chmod +x /usr/local/bin/configure-ldap.sh
# 
docker compose up -d ldap ldapadmin

# either
docker compose exec nextcloud configure-ldap.sh
# or
./scripts/enable-ldap.sh nextcloud
```

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
